### PR TITLE
chore(ci): update project path in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
       dotnet-version: '10.0.x'
       configuration: 'Release'
       runs-on: 'ubuntu-latest'
-      project-path: 'HoneyDrunk.Vault/HoneyDrunk.Vault.sln'
+      project-path: 'HoneyDrunk.Vault/HoneyDrunk.Vault.slnx'
       enable-nuget-publish: true
       nuget-source: 'https://api.nuget.org/v3/index.json'
       actions-ref: 'main'


### PR DESCRIPTION
The `project-path` in `publish.yml` was updated from `HoneyDrunk.Vault/HoneyDrunk.Vault.sln` to `HoneyDrunk.Vault/HoneyDrunk.Vault.slnx`. This ensures the workflow targets the correct solution file, reflecting a potential change in the solution file's name or extension.