### PR TITLE
Add ADR-0005 env-var bootstrap extensions for Vault and App Configuration

### DIFF
--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - 2026-04-11
+## [0.3.0] - 2026-04-11
 
 ### Added
 - Initial provider package.

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-04-11
+## [0.2.1] - 2026-04-11
 
 ### Added
 - Initial provider package.
-- `AddAppConfiguration(IHoneyDrunkBuilder, Action<AppConfigurationOptions>?)` ADR-0005 bootstrap extension.
+- `AddAppConfiguration(IHoneyDrunkBuilder, Action<AppConfigurationOptions>?)` bootstrap extension.
 - Azure App Configuration registration via `AZURE_APPCONFIG_ENDPOINT` and `HONEYDRUNK_NODE_ID`.
 - Development fallback to `appsettings.Development.json` when endpoint is absent.
 - Feature management (`IFeatureManager`) service registration.

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog - HoneyDrunk.Vault.Providers.AppConfiguration
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-04-11
+
+### Added
+- Initial provider package.
+- `AddAppConfiguration(IHoneyDrunkBuilder, Action<AppConfigurationOptions>?)` ADR-0005 bootstrap extension.
+- Azure App Configuration registration via `AZURE_APPCONFIG_ENDPOINT` and `HONEYDRUNK_NODE_ID`.
+- Development fallback to `appsettings.Development.json` when endpoint is absent.
+- Feature management (`IFeatureManager`) service registration.

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Configuration/AppConfigurationOptions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Configuration/AppConfigurationOptions.cs
@@ -1,0 +1,12 @@
+namespace HoneyDrunk.Vault.Providers.AppConfiguration.Configuration;
+
+/// <summary>
+/// Optional bootstrap settings for Azure App Configuration registration.
+/// </summary>
+public sealed class AppConfigurationOptions
+{
+    /// <summary>
+    /// Gets or sets whether unlabeled keys should also be loaded as shared defaults.
+    /// </summary>
+    public bool IncludeUnlabeledKeys { get; set; } = true;
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Configuration/AppConfigurationOptions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Configuration/AppConfigurationOptions.cs
@@ -1,3 +1,5 @@
+using Azure.Core;
+
 namespace HoneyDrunk.Vault.Providers.AppConfiguration.Configuration;
 
 /// <summary>
@@ -6,7 +8,25 @@ namespace HoneyDrunk.Vault.Providers.AppConfiguration.Configuration;
 public sealed class AppConfigurationOptions
 {
     /// <summary>
-    /// Gets or sets whether unlabeled keys should also be loaded as shared defaults.
+    /// Gets or sets a value indicating whether unlabeled keys should also be loaded as shared defaults.
     /// </summary>
     public bool IncludeUnlabeledKeys { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Azure App Configuration provider is optional.
+    /// When <c>true</c>, startup continues if the provider fails to load (useful for local development and testing).
+    /// </summary>
+    public bool Optional { get; set; }
+
+    /// <summary>
+    /// Gets or sets the token credential used for Azure App Configuration and Key Vault reference authentication.
+    /// When <c>null</c>, <see cref="Azure.Identity.DefaultAzureCredential"/> is used.
+    /// </summary>
+    public TokenCredential? Credential { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum time allowed for the initial configuration load from Azure App Configuration.
+    /// When <c>null</c>, the SDK default timeout is used.
+    /// </summary>
+    public TimeSpan? StartupTimeout { get; set; }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
@@ -47,22 +47,25 @@ public static class AppConfigurationBootstrapExtensions
                     "ADR-0005 requires HONEYDRUNK_NODE_ID for App Configuration label partitioning.");
             }
 
-            var credential = new DefaultAzureCredential();
-            if (configuration is IConfigurationManager manager)
+            if (configuration is not IConfigurationManager manager)
             {
-                manager.AddAzureAppConfiguration(appConfigOptions =>
-                {
-                    appConfigOptions.Connect(endpointUri, credential);
-                    appConfigOptions.Select(KeyFilter.Any, nodeId);
-
-                    if (options.IncludeUnlabeledKeys)
-                    {
-                        appConfigOptions.Select(KeyFilter.Any, LabelFilter.Null);
-                    }
-
-                    appConfigOptions.ConfigureKeyVault(keyVault => keyVault.SetCredential(credential));
-                });
+                throw new InvalidOperationException(
+                    "App Configuration bootstrap requires a mutable IConfigurationManager instance on the service collection.");
             }
+
+            var credential = new DefaultAzureCredential();
+            manager.AddAzureAppConfiguration(appConfigOptions =>
+            {
+                appConfigOptions.Connect(endpointUri, credential);
+                appConfigOptions.Select(KeyFilter.Any, nodeId);
+
+                if (options.IncludeUnlabeledKeys)
+                {
+                    appConfigOptions.Select(KeyFilter.Any, LabelFilter.Null);
+                }
+
+                appConfigOptions.ConfigureKeyVault(keyVault => keyVault.SetCredential(credential));
+            });
 
             builder.Services.AddAzureAppConfiguration();
             builder.Services.AddFeatureManagement();
@@ -71,10 +74,13 @@ public static class AppConfigurationBootstrapExtensions
 
         if (BootstrapConfigurationResolver.IsDevelopment(configuration, AspNetCoreEnvironmentSetting, DotNetEnvironmentSetting))
         {
-            if (configuration is IConfigurationManager manager)
+            if (configuration is not IConfigurationManager manager)
             {
-                manager.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true);
+                throw new InvalidOperationException(
+                    "Development bootstrap requires a mutable IConfigurationManager to apply appsettings.Development.json fallback.");
             }
+
+            manager.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true);
 
             builder.Services.AddFeatureManagement();
             return builder;

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
@@ -39,7 +39,8 @@ public static class AppConfigurationBootstrapExtensions
         var configuration = BootstrapConfigurationResolver.Resolve(builder.Services);
         if (BootstrapConfigurationResolver.TryGetEndpoint(configuration, AppConfigurationEndpointSetting, out var endpointUri))
         {
-            var nodeId = configuration[NodeIdSetting];
+            var nodeId = configuration[NodeIdSetting]
+                ?? Environment.GetEnvironmentVariable(NodeIdSetting);
             if (string.IsNullOrWhiteSpace(nodeId))
             {
                 throw new InvalidOperationException(

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
@@ -1,0 +1,87 @@
+using Azure.Identity;
+using HoneyDrunk.Kernel.Abstractions.Hosting;
+using HoneyDrunk.Vault.Providers.AppConfiguration.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FeatureManagement;
+
+namespace HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
+
+/// <summary>
+/// ADR-0005 bootstrap extensions for Azure App Configuration.
+/// </summary>
+public static class AppConfigurationBootstrapExtensions
+{
+    private const string AppConfigurationEndpointSetting = "AZURE_APPCONFIG_ENDPOINT";
+    private const string NodeIdSetting = "HONEYDRUNK_NODE_ID";
+    private const string AspNetCoreEnvironmentSetting = "ASPNETCORE_ENVIRONMENT";
+    private const string DotNetEnvironmentSetting = "DOTNET_ENVIRONMENT";
+
+    /// <summary>
+    /// Adds Azure App Configuration using env-var-driven bootstrap discovery.
+    /// Reads <c>AZURE_APPCONFIG_ENDPOINT</c> and <c>HONEYDRUNK_NODE_ID</c> via <see cref="IConfiguration"/>,
+    /// applies per-Node label partitioning, enables unlabeled shared fallback keys, resolves Key Vault references,
+    /// and registers feature management services (ADR-0005, invariants 17-18).
+    /// </summary>
+    /// <param name="builder">The HoneyDrunk builder.</param>
+    /// <param name="configure">Optional bootstrap configuration.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static IHoneyDrunkBuilder AddAppConfiguration(
+        this IHoneyDrunkBuilder builder,
+        Action<AppConfigurationOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var options = new AppConfigurationOptions();
+        configure?.Invoke(options);
+
+        var configuration = BootstrapConfigurationResolver.Resolve(builder.Services);
+        if (BootstrapConfigurationResolver.TryGetEndpoint(configuration, AppConfigurationEndpointSetting, out var endpointUri))
+        {
+            var nodeId = configuration[NodeIdSetting];
+            if (string.IsNullOrWhiteSpace(nodeId))
+            {
+                throw new InvalidOperationException(
+                    $"Missing required bootstrap setting '{NodeIdSetting}'. " +
+                    "ADR-0005 requires HONEYDRUNK_NODE_ID for App Configuration label partitioning.");
+            }
+
+            var credential = new DefaultAzureCredential();
+            if (configuration is IConfigurationManager manager)
+            {
+                manager.AddAzureAppConfiguration(appConfigOptions =>
+                {
+                    appConfigOptions.Connect(endpointUri, credential);
+                    appConfigOptions.Select(KeyFilter.Any, nodeId);
+
+                    if (options.IncludeUnlabeledKeys)
+                    {
+                        appConfigOptions.Select(KeyFilter.Any, LabelFilter.Null);
+                    }
+
+                    appConfigOptions.ConfigureKeyVault(keyVault => keyVault.SetCredential(credential));
+                });
+            }
+
+            builder.Services.AddAzureAppConfiguration();
+            builder.Services.AddFeatureManagement();
+            return builder;
+        }
+
+        if (BootstrapConfigurationResolver.IsDevelopment(configuration, AspNetCoreEnvironmentSetting, DotNetEnvironmentSetting))
+        {
+            if (configuration is IConfigurationManager manager)
+            {
+                manager.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true);
+            }
+
+            builder.Services.AddFeatureManagement();
+            return builder;
+        }
+
+        throw new InvalidOperationException(
+            $"Missing required bootstrap setting '{AppConfigurationEndpointSetting}'. " +
+            "ADR-0005 requires deployable Nodes to receive AZURE_APPCONFIG_ENDPOINT via environment configuration.");
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
@@ -53,19 +53,26 @@ public static class AppConfigurationBootstrapExtensions
                     "App Configuration bootstrap requires a mutable IConfigurationManager instance on the service collection.");
             }
 
-            var credential = new DefaultAzureCredential();
-            manager.AddAzureAppConfiguration(appConfigOptions =>
-            {
-                appConfigOptions.Connect(endpointUri, credential);
-                appConfigOptions.Select(KeyFilter.Any, nodeId);
-
-                if (options.IncludeUnlabeledKeys)
+            var credential = options.Credential ?? new DefaultAzureCredential();
+            manager.AddAzureAppConfiguration(
+                appConfigOptions =>
                 {
-                    appConfigOptions.Select(KeyFilter.Any, LabelFilter.Null);
-                }
+                    appConfigOptions.Connect(endpointUri, credential);
+                    appConfigOptions.Select(KeyFilter.Any, nodeId);
 
-                appConfigOptions.ConfigureKeyVault(keyVault => keyVault.SetCredential(credential));
-            });
+                    if (options.IncludeUnlabeledKeys)
+                    {
+                        appConfigOptions.Select(KeyFilter.Any, LabelFilter.Null);
+                    }
+
+                    appConfigOptions.ConfigureKeyVault(keyVault => keyVault.SetCredential(credential));
+
+                    if (options.StartupTimeout.HasValue)
+                    {
+                        appConfigOptions.ConfigureStartupOptions(startup => startup.Timeout = options.StartupTimeout.Value);
+                    }
+                },
+                optional: options.Optional);
 
             builder.Services.AddAzureAppConfiguration();
             builder.Services.AddFeatureManagement();

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.FeatureManagement;
 namespace HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
 
 /// <summary>
-/// ADR-0005 bootstrap extensions for Azure App Configuration.
+/// Bootstrap extensions for Azure App Configuration.
 /// </summary>
 public static class AppConfigurationBootstrapExtensions
 {
@@ -22,7 +22,7 @@ public static class AppConfigurationBootstrapExtensions
     /// Adds Azure App Configuration using env-var-driven bootstrap discovery.
     /// Reads <c>AZURE_APPCONFIG_ENDPOINT</c> and <c>HONEYDRUNK_NODE_ID</c> via <see cref="IConfiguration"/>,
     /// applies per-Node label partitioning, enables unlabeled shared fallback keys, resolves Key Vault references,
-    /// and registers feature management services (ADR-0005, invariants 17-18).
+    /// and registers feature management services.
     /// </summary>
     /// <param name="builder">The HoneyDrunk builder.</param>
     /// <param name="configure">Optional bootstrap configuration.</param>
@@ -44,7 +44,7 @@ public static class AppConfigurationBootstrapExtensions
             {
                 throw new InvalidOperationException(
                     $"Missing required bootstrap setting '{NodeIdSetting}'. " +
-                    "ADR-0005 requires HONEYDRUNK_NODE_ID for App Configuration label partitioning.");
+                    "HONEYDRUNK_NODE_ID is required for App Configuration label partitioning.");
             }
 
             if (configuration is not IConfigurationManager manager)
@@ -88,6 +88,6 @@ public static class AppConfigurationBootstrapExtensions
 
         throw new InvalidOperationException(
             $"Missing required bootstrap setting '{AppConfigurationEndpointSetting}'. " +
-            "ADR-0005 requires deployable Nodes to receive AZURE_APPCONFIG_ENDPOINT via environment configuration.");
+            "Deployable services must receive AZURE_APPCONFIG_ENDPOINT via environment configuration.");
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/BootstrapConfigurationResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/BootstrapConfigurationResolver.cs
@@ -3,8 +3,16 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
 
+/// <summary>
+/// Resolves bootstrap configuration from the service collection or environment.
+/// </summary>
 public static class BootstrapConfigurationResolver
 {
+    /// <summary>
+    /// Resolves an <see cref="IConfiguration"/> instance from the service collection or builds a fallback from environment variables.
+    /// </summary>
+    /// <param name="services">The service collection to inspect.</param>
+    /// <returns>The resolved configuration instance.</returns>
     public static IConfiguration Resolve(IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
@@ -20,6 +28,13 @@ public static class BootstrapConfigurationResolver
             .Build();
     }
 
+    /// <summary>
+    /// Determines whether the current environment is Development.
+    /// </summary>
+    /// <param name="configuration">The configuration to check.</param>
+    /// <param name="aspNetCoreEnvironmentSetting">The ASP.NET Core environment variable name.</param>
+    /// <param name="dotNetEnvironmentSetting">The .NET environment variable name.</param>
+    /// <returns><see langword="true"/> if the environment is Development; otherwise, <see langword="false"/>.</returns>
     public static bool IsDevelopment(IConfiguration configuration, string aspNetCoreEnvironmentSetting, string dotNetEnvironmentSetting)
     {
         var environment = configuration[aspNetCoreEnvironmentSetting] ??
@@ -30,6 +45,13 @@ public static class BootstrapConfigurationResolver
         return string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Attempts to read an App Configuration endpoint URI from configuration or environment variables.
+    /// </summary>
+    /// <param name="configuration">The configuration to read from.</param>
+    /// <param name="settingName">The setting key name.</param>
+    /// <param name="endpoint">When this method returns, contains the parsed endpoint URI, or <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if a valid URI was found; otherwise, <see langword="false"/>.</returns>
     public static bool TryGetEndpoint(IConfiguration configuration, string settingName, out Uri? endpoint)
     {
         var value = configuration[settingName];

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/BootstrapConfigurationResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/BootstrapConfigurationResolver.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
+
+public static class BootstrapConfigurationResolver
+{
+    public static IConfiguration Resolve(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var descriptor = services.LastOrDefault(static d => d.ServiceType == typeof(IConfiguration));
+        if (descriptor?.ImplementationInstance is IConfiguration configuration)
+        {
+            return configuration;
+        }
+
+        return new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .Build();
+    }
+
+    public static bool IsDevelopment(IConfiguration configuration, string aspNetCoreEnvironmentSetting, string dotNetEnvironmentSetting)
+    {
+        var environment = configuration[aspNetCoreEnvironmentSetting] ??
+            configuration[dotNetEnvironmentSetting] ??
+            Environment.GetEnvironmentVariable(aspNetCoreEnvironmentSetting) ??
+            Environment.GetEnvironmentVariable(dotNetEnvironmentSetting);
+
+        return string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool TryGetEndpoint(IConfiguration configuration, string settingName, out Uri? endpoint)
+    {
+        var value = configuration[settingName];
+        var isValid = Uri.TryCreate(value, UriKind.Absolute, out var parsed);
+        endpoint = parsed;
+        return isValid;
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/BootstrapConfigurationResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/BootstrapConfigurationResolver.cs
@@ -33,6 +33,11 @@ public static class BootstrapConfigurationResolver
     public static bool TryGetEndpoint(IConfiguration configuration, string settingName, out Uri? endpoint)
     {
         var value = configuration[settingName];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            value = Environment.GetEnvironmentVariable(settingName);
+        }
+
         var isValid = Uri.TryCreate(value, UriKind.Absolute, out var parsed);
         endpoint = parsed;
         return isValid;

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,36 +8,35 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NoWarn>$(NoWarn);CA1873;CA1016</NoWarn>
 
-    <!-- Package Metadata -->
-    <PackageId>HoneyDrunk.Vault.Providers.AzureKeyVault</PackageId>
+    <PackageId>HoneyDrunk.Vault.Providers.AppConfiguration</PackageId>
     <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
-    <Description>Azure Key Vault provider for HoneyDrunk.Vault. Provides enterprise-grade secret management using Azure Key Vault with support for Managed Identity and Service Principal authentication.</Description>
-    <PackageReleaseNotes>v0.2.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
-    <PackageTags>vault;provider;secrets;azure;key-vault;managed-identity;service-principal;authentication;enterprise</PackageTags>
+    <Description>Azure App Configuration bootstrap extensions for HoneyDrunk.Vault using ADR-0005 environment variable discovery.</Description>
+    <PackageReleaseNotes>v0.2.0: Initial release with env-var-driven bootstrap for Azure App Configuration.</PackageReleaseNotes>
+    <PackageTags>vault;provider;app-configuration;azure;feature-flags;configuration;bootstrap</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault</PackageProjectUrl>
 
-    <!-- Symbol Package Configuration -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.4.0" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\HoneyDrunk.Vault\HoneyDrunk.Vault.csproj" />
-    <ProjectReference Include="..\HoneyDrunk.Vault.Providers.File\HoneyDrunk.Vault.Providers.File.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -9,10 +9,10 @@
     <NoWarn>$(NoWarn);CA1873;CA1016</NoWarn>
 
     <PackageId>HoneyDrunk.Vault.Providers.AppConfiguration</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure App Configuration bootstrap extensions for HoneyDrunk.Vault using environment variable discovery.</Description>
-    <PackageReleaseNotes>v0.2.1: Initial release with env-var-driven bootstrap for Azure App Configuration.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Initial release with env-var-driven bootstrap for Azure App Configuration.</PackageReleaseNotes>
     <PackageTags>vault;provider;app-configuration;azure;feature-flags;configuration;bootstrap</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -32,6 +32,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.3.0" />
   </ItemGroup>
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -9,10 +9,10 @@
     <NoWarn>$(NoWarn);CA1873;CA1016</NoWarn>
 
     <PackageId>HoneyDrunk.Vault.Providers.AppConfiguration</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>HoneyDrunk Studios</Authors>
-    <Description>Azure App Configuration bootstrap extensions for HoneyDrunk.Vault using ADR-0005 environment variable discovery.</Description>
-    <PackageReleaseNotes>v0.2.0: Initial release with env-var-driven bootstrap for Azure App Configuration.</PackageReleaseNotes>
+    <Description>Azure App Configuration bootstrap extensions for HoneyDrunk.Vault using environment variable discovery.</Description>
+    <PackageReleaseNotes>v0.2.1: Initial release with env-var-driven bootstrap for Azure App Configuration.</PackageReleaseNotes>
     <PackageTags>vault;provider;app-configuration;azure;feature-flags;configuration;bootstrap</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/README.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/README.md
@@ -1,0 +1,14 @@
+# HoneyDrunk.Vault.Providers.AppConfiguration
+
+ADR-0005 bootstrap extensions for wiring Azure App Configuration from environment variables.
+
+## Bootstrap settings
+
+- `AZURE_APPCONFIG_ENDPOINT`
+- `HONEYDRUNK_NODE_ID`
+
+## Usage
+
+```csharp
+builder.AddAppConfiguration();
+```

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/README.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/README.md
@@ -1,6 +1,6 @@
 # HoneyDrunk.Vault.Providers.AppConfiguration
 
-ADR-0005 bootstrap extensions for wiring Azure App Configuration from environment variables.
+Bootstrap extensions for wiring Azure App Configuration from environment variables.
 
 ## Bootstrap settings
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-11
+
+### Changed
+- Maintenance release aligned with core library version
+- No functional provider changes in this release
+
 ## [0.2.0] - 2026-01-25
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Aws</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>AWS Secrets Manager provider for HoneyDrunk.Vault. Provides secure secret management using AWS Secrets Manager with support for IAM roles, access keys, and EC2 instance profiles.</Description>
-    <PackageReleaseNotes>v0.2.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.1: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;aws;secrets-manager;iam;access-keys;instance-profile;ec2;authentication</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Aws</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>AWS Secrets Manager provider for HoneyDrunk.Vault. Provides secure secret management using AWS Secrets Manager with support for IAM roles, access keys, and EC2 instance profiles.</Description>
-    <PackageReleaseNotes>v0.2.1: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;aws;secrets-manager;iam;access-keys;instance-profile;ec2;authentication</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Env-var bootstrap extension `AddVaultWithAzureKeyVaultBootstrap(IHoneyDrunkBuilder, Action<AzureKeyVaultBootstrapOptions>?)`.
 - Bootstrap behavior: `AZURE_KEYVAULT_URI` + `DefaultAzureCredential`, Development fallback to `secrets/dev-secrets.json`, non-Development throw with clear guidance.
 
+## [0.2.0] - 2026-01-25
+
+### Changed
+- Maintenance release aligned with core library version
+- No functional changes
+
 ## [0.1.0] - 2025-01-01
 
 ### Added

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-04-11
+## [0.2.1] - 2026-04-11
 
 ### Added
-- ADR-0005 env-var bootstrap extension `AddVaultWithAzureKeyVaultBootstrap(IHoneyDrunkBuilder, Action<AzureKeyVaultBootstrapOptions>?)`.
-- Bootstrap behavior: `AZURE_KEYVAULT_URI` + `DefaultAzureCredential`, Development fallback to `secrets/dev-secrets.json`, non-Development throw with ADR-0005 guidance.
+- Env-var bootstrap extension `AddVaultWithAzureKeyVaultBootstrap(IHoneyDrunkBuilder, Action<AzureKeyVaultBootstrapOptions>?)`.
+- Bootstrap behavior: `AZURE_KEYVAULT_URI` + `DefaultAzureCredential`, Development fallback to `secrets/dev-secrets.json`, non-Development throw with clear guidance.
 
 ## [0.1.0] - 2025-01-01
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] - 2026-04-11
 
 ### Added
-- ADR-0005 env-var bootstrap extension `AddVault(IHoneyDrunkBuilder, Action<AzureKeyVaultBootstrapOptions>?)`.
+- ADR-0005 env-var bootstrap extension `AddVaultWithAzureKeyVaultBootstrap(IHoneyDrunkBuilder, Action<AzureKeyVaultBootstrapOptions>?)`.
 - Bootstrap behavior: `AZURE_KEYVAULT_URI` + `DefaultAzureCredential`, Development fallback to `secrets/dev-secrets.json`, non-Development throw with ADR-0005 guidance.
 
 ## [0.1.0] - 2025-01-01

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - 2026-04-11
+## [0.3.0] - 2026-04-11
 
 ### Added
 - Env-var bootstrap extension `AddVaultWithAzureKeyVaultBootstrap(IHoneyDrunkBuilder, Action<AzureKeyVaultBootstrapOptions>?)`.

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-01-25
+## [0.2.0] - 2026-04-11
 
-### Changed
-- Maintenance release aligned with core library version
-- No functional changes
+### Added
+- ADR-0005 env-var bootstrap extension `AddVault(IHoneyDrunkBuilder, Action<AzureKeyVaultBootstrapOptions>?)`.
+- Bootstrap behavior: `AZURE_KEYVAULT_URI` + `DefaultAzureCredential`, Development fallback to `secrets/dev-secrets.json`, non-Development throw with ADR-0005 guidance.
 
 ## [0.1.0] - 2025-01-01
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Configuration/AzureKeyVaultBootstrapOptions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Configuration/AzureKeyVaultBootstrapOptions.cs
@@ -1,7 +1,7 @@
 namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Configuration;
 
 /// <summary>
-/// Configures ADR-0005 bootstrap behavior for Key Vault provider selection.
+/// Configures bootstrap behavior for Key Vault provider selection.
 /// </summary>
 public sealed class AzureKeyVaultBootstrapOptions
 {

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Configuration/AzureKeyVaultBootstrapOptions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Configuration/AzureKeyVaultBootstrapOptions.cs
@@ -1,0 +1,12 @@
+namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Configuration;
+
+/// <summary>
+/// Configures ADR-0005 bootstrap behavior for Key Vault provider selection.
+/// </summary>
+public sealed class AzureKeyVaultBootstrapOptions
+{
+    /// <summary>
+    /// Gets or sets the fallback development secrets file path used when AZURE_KEYVAULT_URI is absent.
+    /// </summary>
+    public string DevelopmentSecretsFilePath { get; set; } = "secrets/dev-secrets.json";
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
@@ -1,13 +1,13 @@
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
 using HoneyDrunk.Kernel.Abstractions.Hosting;
 using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Configuration;
 using HoneyDrunk.Vault.Extensions;
-using HoneyDrunk.Vault.Providers.AzureKeyVault.Services;
 using HoneyDrunk.Vault.Providers.AzureKeyVault.Configuration;
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Services;
 using HoneyDrunk.Vault.Providers.File.Configuration;
 using HoneyDrunk.Vault.Providers.File.Services;
-using Azure.Identity;
-using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
     /// <param name="builder">The HoneyDrunk builder.</param>
     /// <param name="configure">Optional bootstrap customization.</param>
     /// <returns>The builder for chaining.</returns>
-    public static IHoneyDrunkBuilder AddVault(
+    public static IHoneyDrunkBuilder AddVaultWithAzureKeyVaultBootstrap(
         this IHoneyDrunkBuilder builder,
         Action<AzureKeyVaultBootstrapOptions>? configure)
     {
@@ -34,7 +34,7 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
         var bootstrapOptions = new AzureKeyVaultBootstrapOptions();
         configure?.Invoke(bootstrapOptions);
 
-        builder.AddVault(_ => { });
+        builder.AddVault();
 
         var configuration = BootstrapConfigurationResolver.Resolve(builder.Services);
         if (BootstrapConfigurationResolver.TryGetKeyVaultUri(configuration, KeyVaultUriSetting, out var vaultUri))

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
@@ -10,6 +10,7 @@ using HoneyDrunk.Vault.Providers.File.Configuration;
 using HoneyDrunk.Vault.Providers.File.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
@@ -66,9 +67,9 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
 
     private static void RegisterAzureKeyVaultProviders(IServiceCollection services, Uri vaultUri)
     {
-        services.AddSingleton(sp => new SecretClient(vaultUri, new DefaultAzureCredential()));
-        services.AddSingleton<AzureKeyVaultSecretStore>();
-        services.AddSingleton<AzureKeyVaultConfigSource>();
+        services.TryAddSingleton(sp => new SecretClient(vaultUri, new DefaultAzureCredential()));
+        services.TryAddSingleton<AzureKeyVaultSecretStore>();
+        services.TryAddSingleton<AzureKeyVaultConfigSource>();
 
         services.AddSecretProvider(
             sp => sp.GetRequiredService<AzureKeyVaultSecretStore>(),
@@ -85,7 +86,7 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
             sp => new DelegatingConfigSourceProvider(
                 "azure-key-vault",
                 sp.GetRequiredService<AzureKeyVaultConfigSource>(),
-                () => sp.GetRequiredService<AzureKeyVaultSecretStore>().CheckHealthAsync()),
+                ct => sp.GetRequiredService<AzureKeyVaultSecretStore>().CheckHealthAsync(ct)),
             new ProviderRegistration
             {
                 Name = "azure-key-vault",
@@ -124,7 +125,7 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
             sp => new DelegatingConfigSourceProvider(
                 "file",
                 sp.GetRequiredService<FileConfigSource>(),
-                () => sp.GetRequiredService<FileSecretStore>().CheckHealthAsync()),
+                ct => sp.GetRequiredService<FileSecretStore>().CheckHealthAsync(ct)),
             new ProviderRegistration
             {
                 Name = "file",
@@ -138,16 +139,16 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
     private sealed class DelegatingConfigSourceProvider(
         string providerName,
         IConfigSource inner,
-        Func<Task<bool>> healthCheck) : IConfigSourceProvider
+        Func<CancellationToken, Task<bool>> healthCheck) : IConfigSourceProvider
     {
         private readonly IConfigSource _inner = inner;
-        private readonly Func<Task<bool>> _healthCheck = healthCheck;
+        private readonly Func<CancellationToken, Task<bool>> _healthCheck = healthCheck;
 
         public string ProviderName { get; } = providerName;
 
         public bool IsAvailable => true;
 
-        public Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default) => _healthCheck();
+        public Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default) => _healthCheck(cancellationToken);
 
         public Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default) =>
             _inner.GetConfigValueAsync(key, cancellationToken);

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
@@ -16,9 +16,9 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
     private const string DotNetEnvironmentSetting = "DOTNET_ENVIRONMENT";
 
     /// <summary>
-    /// Adds Vault bootstrap wiring using ADR-0005 environment-variable discovery.
+    /// Adds Vault bootstrap wiring using environment-variable discovery.
     /// Reads <c>AZURE_KEYVAULT_URI</c> from <see cref="IConfiguration"/> and wires Azure Key Vault with
-    /// <see cref="Azure.Identity.DefaultAzureCredential"/> when present (ADR-0005, invariants 17 and 18).
+    /// <see cref="Azure.Identity.DefaultAzureCredential"/> when present.
     /// If the setting is missing in Development, falls back to file-based secrets. If missing outside
     /// Development, throws a descriptive bootstrap exception.
     /// </summary>
@@ -60,6 +60,6 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
 
         throw new InvalidOperationException(
             $"Missing required bootstrap setting '{KeyVaultUriSetting}'. " +
-            "ADR-0005 requires deployable Nodes to receive AZURE_KEYVAULT_URI via environment configuration.");
+            "Deployable services must receive AZURE_KEYVAULT_URI via environment configuration.");
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
@@ -1,8 +1,16 @@
 using HoneyDrunk.Kernel.Abstractions.Hosting;
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Configuration;
 using HoneyDrunk.Vault.Extensions;
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Services;
 using HoneyDrunk.Vault.Providers.AzureKeyVault.Configuration;
-using HoneyDrunk.Vault.Providers.File.Extensions;
+using HoneyDrunk.Vault.Providers.File.Configuration;
+using HoneyDrunk.Vault.Providers.File.Services;
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
 
@@ -27,7 +35,7 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
     /// <returns>The builder for chaining.</returns>
     public static IHoneyDrunkBuilder AddVaultWithAzureKeyVaultBootstrap(
         this IHoneyDrunkBuilder builder,
-        Action<AzureKeyVaultBootstrapOptions>? configure)
+        Action<AzureKeyVaultBootstrapOptions>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -39,21 +47,14 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
         var configuration = BootstrapConfigurationResolver.Resolve(builder.Services);
         if (BootstrapConfigurationResolver.TryGetKeyVaultUri(configuration, KeyVaultUriSetting, out var vaultUri))
         {
-            builder.Services.AddVaultWithAzureKeyVault(new AzureKeyVaultOptions
-            {
-                VaultUri = vaultUri,
-                UseManagedIdentity = true,
-            });
+            RegisterAzureKeyVaultProviders(builder.Services, vaultUri);
 
             return builder;
         }
 
         if (BootstrapConfigurationResolver.IsDevelopment(configuration, AspNetCoreEnvironmentSetting, DotNetEnvironmentSetting))
         {
-            builder.Services.AddVaultWithFile(options =>
-            {
-                options.SecretsFilePath = bootstrapOptions.DevelopmentSecretsFilePath;
-            });
+            RegisterFileFallbackProviders(builder.Services, bootstrapOptions);
 
             return builder;
         }
@@ -61,5 +62,103 @@ public static class AzureKeyVaultHoneyDrunkBuilderExtensions
         throw new InvalidOperationException(
             $"Missing required bootstrap setting '{KeyVaultUriSetting}'. " +
             "Deployable services must receive AZURE_KEYVAULT_URI via environment configuration.");
+    }
+
+    private static void RegisterAzureKeyVaultProviders(IServiceCollection services, Uri vaultUri)
+    {
+        services.AddSingleton(sp => new SecretClient(vaultUri, new DefaultAzureCredential()));
+        services.AddSingleton<AzureKeyVaultSecretStore>();
+        services.AddSingleton<AzureKeyVaultConfigSource>();
+
+        services.AddSecretProvider(
+            sp => sp.GetRequiredService<AzureKeyVaultSecretStore>(),
+            new ProviderRegistration
+            {
+                Name = "azure-key-vault",
+                ProviderType = ProviderType.AzureKeyVault,
+                Priority = 0,
+                IsEnabled = true,
+                IsRequired = true,
+            });
+
+        services.AddConfigSourceProvider(
+            sp => new DelegatingConfigSourceProvider(
+                "azure-key-vault",
+                sp.GetRequiredService<AzureKeyVaultConfigSource>(),
+                () => sp.GetRequiredService<AzureKeyVaultSecretStore>().CheckHealthAsync()),
+            new ProviderRegistration
+            {
+                Name = "azure-key-vault",
+                ProviderType = ProviderType.AzureKeyVault,
+                Priority = 0,
+                IsEnabled = true,
+                IsRequired = true,
+            });
+    }
+
+    private static void RegisterFileFallbackProviders(
+        IServiceCollection services,
+        AzureKeyVaultBootstrapOptions bootstrapOptions)
+    {
+        services.AddSingleton<IOptions<FileVaultOptions>>(
+            Options.Create(new FileVaultOptions
+            {
+                SecretsFilePath = bootstrapOptions.DevelopmentSecretsFilePath,
+            }));
+
+        services.AddSingleton<FileSecretStore>();
+        services.AddSingleton<FileConfigSource>();
+
+        services.AddSecretProvider(
+            sp => sp.GetRequiredService<FileSecretStore>(),
+            new ProviderRegistration
+            {
+                Name = "file",
+                ProviderType = ProviderType.File,
+                Priority = 100,
+                IsEnabled = true,
+                IsRequired = false,
+            });
+
+        services.AddConfigSourceProvider(
+            sp => new DelegatingConfigSourceProvider(
+                "file",
+                sp.GetRequiredService<FileConfigSource>(),
+                () => sp.GetRequiredService<FileSecretStore>().CheckHealthAsync()),
+            new ProviderRegistration
+            {
+                Name = "file",
+                ProviderType = ProviderType.File,
+                Priority = 100,
+                IsEnabled = true,
+                IsRequired = false,
+            });
+    }
+
+    private sealed class DelegatingConfigSourceProvider(
+        string providerName,
+        IConfigSource inner,
+        Func<Task<bool>> healthCheck) : IConfigSourceProvider
+    {
+        private readonly IConfigSource _inner = inner;
+        private readonly Func<Task<bool>> _healthCheck = healthCheck;
+
+        public string ProviderName { get; } = providerName;
+
+        public bool IsAvailable => true;
+
+        public Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default) => _healthCheck();
+
+        public Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default) =>
+            _inner.GetConfigValueAsync(key, cancellationToken);
+
+        public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default) =>
+            _inner.TryGetConfigValueAsync(key, cancellationToken);
+
+        public Task<T> GetConfigValueAsync<T>(string key, CancellationToken cancellationToken = default) =>
+            _inner.GetConfigValueAsync<T>(key, cancellationToken);
+
+        public Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default) =>
+            _inner.TryGetConfigValueAsync(key, defaultValue, cancellationToken);
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensions.cs
@@ -1,0 +1,65 @@
+using HoneyDrunk.Kernel.Abstractions.Hosting;
+using HoneyDrunk.Vault.Extensions;
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Configuration;
+using HoneyDrunk.Vault.Providers.File.Extensions;
+using Microsoft.Extensions.Configuration;
+
+namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
+
+/// <summary>
+/// Bootstrap extension methods for Azure Key Vault provider integration with HoneyDrunk.Kernel.
+/// </summary>
+public static class AzureKeyVaultHoneyDrunkBuilderExtensions
+{
+    private const string KeyVaultUriSetting = "AZURE_KEYVAULT_URI";
+    private const string AspNetCoreEnvironmentSetting = "ASPNETCORE_ENVIRONMENT";
+    private const string DotNetEnvironmentSetting = "DOTNET_ENVIRONMENT";
+
+    /// <summary>
+    /// Adds Vault bootstrap wiring using ADR-0005 environment-variable discovery.
+    /// Reads <c>AZURE_KEYVAULT_URI</c> from <see cref="IConfiguration"/> and wires Azure Key Vault with
+    /// <see cref="Azure.Identity.DefaultAzureCredential"/> when present (ADR-0005, invariants 17 and 18).
+    /// If the setting is missing in Development, falls back to file-based secrets. If missing outside
+    /// Development, throws a descriptive bootstrap exception.
+    /// </summary>
+    /// <param name="builder">The HoneyDrunk builder.</param>
+    /// <param name="configure">Optional bootstrap customization.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static IHoneyDrunkBuilder AddVault(
+        this IHoneyDrunkBuilder builder,
+        Action<AzureKeyVaultBootstrapOptions>? configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var bootstrapOptions = new AzureKeyVaultBootstrapOptions();
+        configure?.Invoke(bootstrapOptions);
+
+        builder.AddVault(_ => { });
+
+        var configuration = BootstrapConfigurationResolver.Resolve(builder.Services);
+        if (BootstrapConfigurationResolver.TryGetKeyVaultUri(configuration, KeyVaultUriSetting, out var vaultUri))
+        {
+            builder.Services.AddVaultWithAzureKeyVault(new AzureKeyVaultOptions
+            {
+                VaultUri = vaultUri,
+                UseManagedIdentity = true,
+            });
+
+            return builder;
+        }
+
+        if (BootstrapConfigurationResolver.IsDevelopment(configuration, AspNetCoreEnvironmentSetting, DotNetEnvironmentSetting))
+        {
+            builder.Services.AddVaultWithFile(options =>
+            {
+                options.SecretsFilePath = bootstrapOptions.DevelopmentSecretsFilePath;
+            });
+
+            return builder;
+        }
+
+        throw new InvalidOperationException(
+            $"Missing required bootstrap setting '{KeyVaultUriSetting}'. " +
+            "ADR-0005 requires deployable Nodes to receive AZURE_KEYVAULT_URI via environment configuration.");
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/BootstrapConfigurationResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/BootstrapConfigurationResolver.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
+
+public static class BootstrapConfigurationResolver
+{
+    public static IConfiguration Resolve(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var descriptor = services.LastOrDefault(static d => d.ServiceType == typeof(IConfiguration));
+        if (descriptor?.ImplementationInstance is IConfiguration configuration)
+        {
+            return configuration;
+        }
+
+        return new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .Build();
+    }
+
+    public static bool IsDevelopment(IConfiguration configuration, string aspNetCoreEnvironmentSetting, string dotNetEnvironmentSetting)
+    {
+        var environment = configuration[aspNetCoreEnvironmentSetting] ??
+            configuration[dotNetEnvironmentSetting] ??
+            Environment.GetEnvironmentVariable(aspNetCoreEnvironmentSetting) ??
+            Environment.GetEnvironmentVariable(dotNetEnvironmentSetting);
+
+        return string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool TryGetKeyVaultUri(IConfiguration configuration, string settingName, out Uri? vaultUri)
+    {
+        var value = configuration[settingName];
+        var isValid = Uri.TryCreate(value, UriKind.Absolute, out var uri);
+        vaultUri = uri;
+        return isValid;
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/BootstrapConfigurationResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/BootstrapConfigurationResolver.cs
@@ -33,6 +33,11 @@ public static class BootstrapConfigurationResolver
     public static bool TryGetKeyVaultUri(IConfiguration configuration, string settingName, out Uri? vaultUri)
     {
         var value = configuration[settingName];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            value = Environment.GetEnvironmentVariable(settingName);
+        }
+
         var isValid = Uri.TryCreate(value, UriKind.Absolute, out var uri);
         vaultUri = uri;
         return isValid;

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/BootstrapConfigurationResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/BootstrapConfigurationResolver.cs
@@ -1,10 +1,19 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics.CodeAnalysis;
 
 namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
 
+/// <summary>
+/// Resolves bootstrap configuration from the service collection or environment.
+/// </summary>
 public static class BootstrapConfigurationResolver
 {
+    /// <summary>
+    /// Resolves an <see cref="IConfiguration"/> instance from the service collection or builds a fallback from environment variables.
+    /// </summary>
+    /// <param name="services">The service collection to inspect.</param>
+    /// <returns>The resolved configuration instance.</returns>
     public static IConfiguration Resolve(IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
@@ -20,6 +29,13 @@ public static class BootstrapConfigurationResolver
             .Build();
     }
 
+    /// <summary>
+    /// Determines whether the current environment is Development.
+    /// </summary>
+    /// <param name="configuration">The configuration to check.</param>
+    /// <param name="aspNetCoreEnvironmentSetting">The ASP.NET Core environment variable name.</param>
+    /// <param name="dotNetEnvironmentSetting">The .NET environment variable name.</param>
+    /// <returns><see langword="true"/> if the environment is Development; otherwise, <see langword="false"/>.</returns>
     public static bool IsDevelopment(IConfiguration configuration, string aspNetCoreEnvironmentSetting, string dotNetEnvironmentSetting)
     {
         var environment = configuration[aspNetCoreEnvironmentSetting] ??
@@ -30,7 +46,14 @@ public static class BootstrapConfigurationResolver
         return string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase);
     }
 
-    public static bool TryGetKeyVaultUri(IConfiguration configuration, string settingName, out Uri? vaultUri)
+    /// <summary>
+    /// Attempts to read a Key Vault URI from configuration or environment variables.
+    /// </summary>
+    /// <param name="configuration">The configuration to read from.</param>
+    /// <param name="settingName">The setting key name.</param>
+    /// <param name="vaultUri">When this method returns, contains the parsed vault URI, or <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if a valid URI was found; otherwise, <see langword="false"/>.</returns>
+    public static bool TryGetKeyVaultUri(IConfiguration configuration, string settingName, [NotNullWhen(true)] out Uri? vaultUri)
     {
         var value = configuration[settingName];
         if (string.IsNullOrWhiteSpace(value))

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -37,7 +37,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\HoneyDrunk.Vault\HoneyDrunk.Vault.csproj" />
-    <ProjectReference Include="..\HoneyDrunk.Vault.Providers.File\HoneyDrunk.Vault.Providers.File.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Vault.Providers.File\HoneyDrunk.Vault.Providers.File.csproj">
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.AzureKeyVault</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Key Vault provider for HoneyDrunk.Vault. Provides enterprise-grade secret management using Azure Key Vault with support for Managed Identity and Service Principal authentication.</Description>
-    <PackageReleaseNotes>v0.2.1: Added environment-variable bootstrap API updates and naming fixes. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Added environment-variable bootstrap API updates and naming fixes. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;azure;key-vault;managed-identity;service-principal;authentication;enterprise</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.AzureKeyVault</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Key Vault provider for HoneyDrunk.Vault. Provides enterprise-grade secret management using Azure Key Vault with support for Managed Identity and Service Principal authentication.</Description>
-    <PackageReleaseNotes>v0.2.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.1: Added environment-variable bootstrap API updates and naming fixes. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;azure;key-vault;managed-identity;service-principal;authentication;enterprise</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -37,9 +37,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\HoneyDrunk.Vault\HoneyDrunk.Vault.csproj" />
-    <ProjectReference Include="..\HoneyDrunk.Vault.Providers.File\HoneyDrunk.Vault.Providers.File.csproj">
-      <PrivateAssets>all</PrivateAssets>
-    </ProjectReference>
+    <ProjectReference Include="..\HoneyDrunk.Vault.Providers.File\HoneyDrunk.Vault.Providers.File.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-11
+
+### Changed
+- Maintenance release aligned with core library version and provider packaging metadata
+- No functional provider changes in this release
+
 ## [0.2.0] - 2026-01-25
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Configuration</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>.NET Configuration provider for HoneyDrunk.Vault. Enables reading secrets and configuration from standard .NET configuration sources (appsettings.json, environment variables, user secrets).</Description>
-    <PackageReleaseNotes>v0.2.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.1: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;configuration;secrets;appsettings;environment-variables;user-secrets;dotnet-config</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Configuration</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>.NET Configuration provider for HoneyDrunk.Vault. Enables reading secrets and configuration from standard .NET configuration sources (appsettings.json, environment variables, user secrets).</Description>
-    <PackageReleaseNotes>v0.2.1: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;configuration;secrets;appsettings;environment-variables;user-secrets;dotnet-config</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
@@ -13,7 +13,7 @@
     <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>.NET Configuration provider for HoneyDrunk.Vault. Enables reading secrets and configuration from standard .NET configuration sources (appsettings.json, environment variables, user secrets).</Description>
-    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with the core library version and provider packaging metadata.</PackageReleaseNotes>
     <PackageTags>vault;provider;configuration;secrets;appsettings;environment-variables;user-secrets;dotnet-config</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-11
+
+### Changed
+- Maintenance release aligned with core library version
+- No functional provider changes in this release
+
 ## [0.2.0] - 2026-01-25
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.File</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>File-based secrets and configuration provider for HoneyDrunk.Vault. Ideal for local development and testing with support for file watching and optional encryption.</Description>
-    <PackageReleaseNotes>v0.2.1: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;configuration;file;development;testing;file-watcher</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
@@ -13,7 +13,7 @@
     <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>File-based secrets and configuration provider for HoneyDrunk.Vault. Ideal for local development and testing with support for file watching and optional encryption.</Description>
-    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with the core library version. No functional provider changes in this release.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;configuration;file;development;testing;file-watcher</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.File</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>File-based secrets and configuration provider for HoneyDrunk.Vault. Ideal for local development and testing with support for file watching and optional encryption.</Description>
-    <PackageReleaseNotes>v0.2.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.1: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;configuration;file;development;testing;file-watcher</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-11
+
+### Changed
+- Package metadata and release documentation alignment update
+- No functional provider changes in this release
+
 ## [0.2.0] - 2026-01-25
 
 ### Added

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Configuration/InMemoryVaultOptions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Configuration/InMemoryVaultOptions.cs
@@ -8,12 +8,12 @@ public sealed class InMemoryVaultOptions
     /// <summary>
     /// Gets the dictionary of secrets. Key is the secret name, value is the secret value.
     /// </summary>
-    public Dictionary<string, string> Secrets { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, string> Secrets { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Gets the dictionary of configuration values. Key is the configuration key, value is the configuration value.
     /// </summary>
-    public Dictionary<string, string> ConfigurationValues { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, string> ConfigurationValues { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Adds a secret to the in-memory store.

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.InMemory</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory provider for HoneyDrunk.Vault. Ideal for unit testing and integration testing with fast, thread-safe secret and configuration storage.</Description>
-    <PackageReleaseNotes>v0.2.1: InMemoryConfigSource now implements IConfigSourceProvider for full composite stack support. Added ProviderName, IsAvailable, and CheckHealthAsync members. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: InMemoryConfigSource now implements IConfigSourceProvider for full composite stack support. Added ProviderName, IsAvailable, and CheckHealthAsync members. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;testing;unit-testing;in-memory;mock;development</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
@@ -13,7 +13,7 @@
     <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory provider for HoneyDrunk.Vault. Ideal for unit testing and integration testing with fast, thread-safe secret and configuration storage.</Description>
-    <PackageReleaseNotes>v0.3.0: InMemoryConfigSource now implements IConfigSourceProvider for full composite stack support. Added ProviderName, IsAvailable, and CheckHealthAsync members. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Package metadata and release documentation alignment update. See CHANGELOG.md for version-specific details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;testing;unit-testing;in-memory;mock;development</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.InMemory</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory provider for HoneyDrunk.Vault. Ideal for unit testing and integration testing with fast, thread-safe secret and configuration storage.</Description>
-    <PackageReleaseNotes>v0.2.0: InMemoryConfigSource now implements IConfigSourceProvider for full composite stack support. Added ProviderName, IsAvailable, and CheckHealthAsync members. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.1: InMemoryConfigSource now implements IConfigSourceProvider for full composite stack support. Added ProviderName, IsAvailable, and CheckHealthAsync members. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;testing;unit-testing;in-memory;mock;development</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapConfigurationResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapConfigurationResolverTests.cs
@@ -6,6 +6,7 @@ namespace HoneyDrunk.Vault.Tests.Extensions;
 /// <summary>
 /// Unit tests for App Configuration bootstrap resolution.
 /// </summary>
+[Collection("EnvironmentVariables")]
 public sealed class AppConfigurationBootstrapConfigurationResolverTests
 {
     /// <summary>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapConfigurationResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapConfigurationResolverTests.cs
@@ -1,0 +1,52 @@
+using HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
+using Microsoft.Extensions.Configuration;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+/// <summary>
+/// Unit tests for App Configuration bootstrap resolution.
+/// </summary>
+public sealed class AppConfigurationBootstrapConfigurationResolverTests
+{
+    [Fact]
+    public void TryGetEndpoint_ReturnsTrue_WhenEndpointPresent()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AZURE_APPCONFIG_ENDPOINT"] = "https://appcs-hd-shared-prod.azconfig.io",
+            })
+            .Build();
+
+        var result = BootstrapConfigurationResolver.TryGetEndpoint(configuration, "AZURE_APPCONFIG_ENDPOINT", out var endpoint);
+
+        Assert.True(result);
+        Assert.NotNull(endpoint);
+    }
+
+    [Fact]
+    public void IsDevelopment_ReturnsTrue_WhenEnvironmentIsDevelopment()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DOTNET_ENVIRONMENT"] = "Development",
+            })
+            .Build();
+
+        var isDevelopment = BootstrapConfigurationResolver.IsDevelopment(configuration, "ASPNETCORE_ENVIRONMENT", "DOTNET_ENVIRONMENT");
+
+        Assert.True(isDevelopment);
+    }
+
+    [Fact]
+    public void TryGetEndpoint_ReturnsFalse_WhenEndpointMissing()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var result = BootstrapConfigurationResolver.TryGetEndpoint(configuration, "AZURE_APPCONFIG_ENDPOINT", out var endpoint);
+
+        Assert.False(result);
+        Assert.Null(endpoint);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapConfigurationResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapConfigurationResolverTests.cs
@@ -49,4 +49,26 @@ public sealed class AppConfigurationBootstrapConfigurationResolverTests
         Assert.False(result);
         Assert.Null(endpoint);
     }
+
+    [Fact]
+    public void TryGetEndpoint_ReadsEnvironmentVariable_WhenMissingFromConfiguration()
+    {
+        const string setting = "AZURE_APPCONFIG_ENDPOINT";
+        var original = Environment.GetEnvironmentVariable(setting);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(setting, "https://appcs-env.azconfig.io");
+            var configuration = new ConfigurationBuilder().Build();
+
+            var result = BootstrapConfigurationResolver.TryGetEndpoint(configuration, setting, out var endpoint);
+
+            Assert.True(result);
+            Assert.NotNull(endpoint);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(setting, original);
+        }
+    }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapConfigurationResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapConfigurationResolverTests.cs
@@ -8,6 +8,9 @@ namespace HoneyDrunk.Vault.Tests.Extensions;
 /// </summary>
 public sealed class AppConfigurationBootstrapConfigurationResolverTests
 {
+    /// <summary>
+    /// Verifies that TryGetEndpoint returns true when a valid endpoint is present.
+    /// </summary>
     [Fact]
     public void TryGetEndpoint_ReturnsTrue_WhenEndpointPresent()
     {
@@ -24,6 +27,9 @@ public sealed class AppConfigurationBootstrapConfigurationResolverTests
         Assert.NotNull(endpoint);
     }
 
+    /// <summary>
+    /// Verifies that IsDevelopment returns true for a Development environment.
+    /// </summary>
     [Fact]
     public void IsDevelopment_ReturnsTrue_WhenEnvironmentIsDevelopment()
     {
@@ -39,6 +45,9 @@ public sealed class AppConfigurationBootstrapConfigurationResolverTests
         Assert.True(isDevelopment);
     }
 
+    /// <summary>
+    /// Verifies that TryGetEndpoint returns false when the endpoint is missing.
+    /// </summary>
     [Fact]
     public void TryGetEndpoint_ReturnsFalse_WhenEndpointMissing()
     {
@@ -50,6 +59,9 @@ public sealed class AppConfigurationBootstrapConfigurationResolverTests
         Assert.Null(endpoint);
     }
 
+    /// <summary>
+    /// Verifies that TryGetEndpoint falls back to reading an environment variable.
+    /// </summary>
     [Fact]
     public void TryGetEndpoint_ReadsEnvironmentVariable_WhenMissingFromConfiguration()
     {

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
@@ -1,0 +1,65 @@
+using HoneyDrunk.Kernel.Abstractions.Hosting;
+using HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.Extensions.Configuration.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+public sealed class AppConfigurationBootstrapExtensionsTests
+{
+    [Fact]
+    public void AddAppConfiguration_RegistersAzureSource_WhenEndpointPresent()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationManager();
+        configuration["AZURE_APPCONFIG_ENDPOINT"] = "https://appcs-test.azconfig.io";
+        configuration["HONEYDRUNK_NODE_ID"] = "orders";
+        services.AddSingleton<IConfiguration>(configuration);
+
+        var builder = CreateBuilder(services);
+
+        var result = builder.AddAppConfiguration();
+
+        Assert.Same(builder, result);
+        Assert.Contains(configuration.Sources, s => s.GetType().Name.Contains("AzureAppConfiguration", StringComparison.Ordinal));
+        Assert.Contains(services, d => d.ServiceType.FullName == "Microsoft.FeatureManagement.IFeatureManager");
+    }
+
+    [Fact]
+    public void AddAppConfiguration_AddsDevelopmentJson_WhenDevelopmentAndEndpointMissing()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationManager();
+        configuration["DOTNET_ENVIRONMENT"] = "Development";
+        services.AddSingleton<IConfiguration>(configuration);
+
+        var builder = CreateBuilder(services);
+
+        builder.AddAppConfiguration();
+
+        Assert.Contains(configuration.Sources, s => s is JsonConfigurationSource json && json.Path == "appsettings.Development.json");
+    }
+
+    [Fact]
+    public void AddAppConfiguration_Throws_WhenNonDevelopmentAndEndpointMissing()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationManager();
+        configuration["DOTNET_ENVIRONMENT"] = "Production";
+        services.AddSingleton<IConfiguration>(configuration);
+
+        var builder = CreateBuilder(services);
+
+        Assert.Throws<InvalidOperationException>(() => builder.AddAppConfiguration());
+    }
+
+    private static IHoneyDrunkBuilder CreateBuilder(IServiceCollection services)
+    {
+        var builderMock = new Mock<IHoneyDrunkBuilder>();
+        builderMock.SetupGet(static b => b.Services).Returns(services);
+        return builderMock.Object;
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
@@ -1,3 +1,4 @@
+using Azure.Core;
 using HoneyDrunk.Kernel.Abstractions.Hosting;
 using HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
 using Microsoft.Extensions.Configuration;
@@ -7,31 +8,49 @@ using Moq;
 
 namespace HoneyDrunk.Vault.Tests.Extensions;
 
+/// <summary>
+/// Tests for <see cref="AppConfigurationBootstrapExtensions"/>.
+/// </summary>
 public sealed class AppConfigurationBootstrapExtensionsTests
 {
+    /// <summary>
+    /// Verifies that Azure App Configuration source is registered when an endpoint is present.
+    /// </summary>
     [Fact]
     public void AddAppConfiguration_RegistersAzureSource_WhenEndpointPresent()
     {
         var services = new ServiceCollection();
-        var configuration = new ConfigurationManager();
+        using var configuration = new ConfigurationManager();
         configuration["AZURE_APPCONFIG_ENDPOINT"] = "https://appcs-test.azconfig.io";
         configuration["HONEYDRUNK_NODE_ID"] = "orders";
         services.AddSingleton<IConfiguration>(configuration);
 
         var builder = CreateBuilder(services);
+        var mockCredential = new Mock<TokenCredential>();
+        mockCredential
+            .Setup(c => c.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()))
+            .Returns(new ValueTask<AccessToken>(new AccessToken("fake-token", DateTimeOffset.MaxValue)));
 
-        var result = builder.AddAppConfiguration();
+        var result = builder.AddAppConfiguration(o =>
+        {
+            o.Optional = true;
+            o.Credential = mockCredential.Object;
+            o.StartupTimeout = TimeSpan.FromMilliseconds(1);
+        });
 
         Assert.Same(builder, result);
         Assert.Contains(configuration.Sources, s => s.GetType().Name.Contains("AzureAppConfiguration", StringComparison.Ordinal));
         Assert.Contains(services, d => d.ServiceType.FullName == "Microsoft.FeatureManagement.IFeatureManager");
     }
 
+    /// <summary>
+    /// Verifies that a Development JSON fallback is added when in Development without an endpoint.
+    /// </summary>
     [Fact]
     public void AddAppConfiguration_AddsDevelopmentJson_WhenDevelopmentAndEndpointMissing()
     {
         var services = new ServiceCollection();
-        var configuration = new ConfigurationManager();
+        using var configuration = new ConfigurationManager();
         configuration["DOTNET_ENVIRONMENT"] = "Development";
         services.AddSingleton<IConfiguration>(configuration);
 
@@ -42,11 +61,14 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         Assert.Contains(configuration.Sources, s => s is JsonConfigurationSource json && json.Path == "appsettings.Development.json");
     }
 
+    /// <summary>
+    /// Verifies that an exception is thrown when not in Development and no endpoint is configured.
+    /// </summary>
     [Fact]
     public void AddAppConfiguration_Throws_WhenNonDevelopmentAndEndpointMissing()
     {
         var services = new ServiceCollection();
-        var configuration = new ConfigurationManager();
+        using var configuration = new ConfigurationManager();
         configuration["DOTNET_ENVIRONMENT"] = "Production";
         services.AddSingleton<IConfiguration>(configuration);
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
@@ -1,7 +1,6 @@
 using HoneyDrunk.Kernel.Abstractions.Hosting;
 using HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultBootstrapConfigurationResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultBootstrapConfigurationResolverTests.cs
@@ -46,4 +46,26 @@ public sealed class AzureKeyVaultBootstrapConfigurationResolverTests
         Assert.False(result);
         Assert.Null(vaultUri);
     }
+
+    [Fact]
+    public void TryGetKeyVaultUri_ReadsEnvironmentVariable_WhenMissingFromConfiguration()
+    {
+        const string setting = "AZURE_KEYVAULT_URI";
+        var original = Environment.GetEnvironmentVariable(setting);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(setting, "https://kv-env.vault.azure.net/");
+            var configuration = new ConfigurationBuilder().Build();
+
+            var result = BootstrapConfigurationResolver.TryGetKeyVaultUri(configuration, setting, out var vaultUri);
+
+            Assert.True(result);
+            Assert.NotNull(vaultUri);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(setting, original);
+        }
+    }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultBootstrapConfigurationResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultBootstrapConfigurationResolverTests.cs
@@ -3,8 +3,14 @@ using Microsoft.Extensions.Configuration;
 
 namespace HoneyDrunk.Vault.Tests.Extensions;
 
+/// <summary>
+/// Tests for Azure Key Vault bootstrap configuration resolution.
+/// </summary>
 public sealed class AzureKeyVaultBootstrapConfigurationResolverTests
 {
+    /// <summary>
+    /// Verifies that TryGetKeyVaultUri returns true when a valid URI is present.
+    /// </summary>
     [Fact]
     public void TryGetKeyVaultUri_ReturnsTrue_WhenUriPresent()
     {
@@ -21,6 +27,9 @@ public sealed class AzureKeyVaultBootstrapConfigurationResolverTests
         Assert.NotNull(vaultUri);
     }
 
+    /// <summary>
+    /// Verifies that IsDevelopment returns true for a Development environment.
+    /// </summary>
     [Fact]
     public void IsDevelopment_ReturnsTrue_WhenEnvironmentIsDevelopment()
     {
@@ -36,6 +45,9 @@ public sealed class AzureKeyVaultBootstrapConfigurationResolverTests
         Assert.True(isDevelopment);
     }
 
+    /// <summary>
+    /// Verifies that TryGetKeyVaultUri returns false when the URI is missing.
+    /// </summary>
     [Fact]
     public void TryGetKeyVaultUri_ReturnsFalse_WhenUriMissing()
     {
@@ -47,6 +59,9 @@ public sealed class AzureKeyVaultBootstrapConfigurationResolverTests
         Assert.Null(vaultUri);
     }
 
+    /// <summary>
+    /// Verifies that TryGetKeyVaultUri falls back to reading an environment variable.
+    /// </summary>
     [Fact]
     public void TryGetKeyVaultUri_ReadsEnvironmentVariable_WhenMissingFromConfiguration()
     {

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultBootstrapConfigurationResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultBootstrapConfigurationResolverTests.cs
@@ -1,0 +1,49 @@
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
+using Microsoft.Extensions.Configuration;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+public sealed class AzureKeyVaultBootstrapConfigurationResolverTests
+{
+    [Fact]
+    public void TryGetKeyVaultUri_ReturnsTrue_WhenUriPresent()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AZURE_KEYVAULT_URI"] = "https://kv-hd-orders-prod.vault.azure.net/",
+            })
+            .Build();
+
+        var result = BootstrapConfigurationResolver.TryGetKeyVaultUri(configuration, "AZURE_KEYVAULT_URI", out var vaultUri);
+
+        Assert.True(result);
+        Assert.NotNull(vaultUri);
+    }
+
+    [Fact]
+    public void IsDevelopment_ReturnsTrue_WhenEnvironmentIsDevelopment()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ASPNETCORE_ENVIRONMENT"] = "Development",
+            })
+            .Build();
+
+        var isDevelopment = BootstrapConfigurationResolver.IsDevelopment(configuration, "ASPNETCORE_ENVIRONMENT", "DOTNET_ENVIRONMENT");
+
+        Assert.True(isDevelopment);
+    }
+
+    [Fact]
+    public void TryGetKeyVaultUri_ReturnsFalse_WhenUriMissing()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        var result = BootstrapConfigurationResolver.TryGetKeyVaultUri(configuration, "AZURE_KEYVAULT_URI", out var vaultUri);
+
+        Assert.False(result);
+        Assert.Null(vaultUri);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultBootstrapConfigurationResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultBootstrapConfigurationResolverTests.cs
@@ -6,6 +6,7 @@ namespace HoneyDrunk.Vault.Tests.Extensions;
 /// <summary>
 /// Tests for Azure Key Vault bootstrap configuration resolution.
 /// </summary>
+[Collection("EnvironmentVariables")]
 public sealed class AzureKeyVaultBootstrapConfigurationResolverTests
 {
     /// <summary>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensionsTests.cs
@@ -1,7 +1,7 @@
 using HoneyDrunk.Kernel.Abstractions.Hosting;
-using HoneyDrunk.Vault.Services;
 using HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
 using HoneyDrunk.Vault.Providers.File.Configuration;
+using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -9,13 +9,19 @@ using Moq;
 
 namespace HoneyDrunk.Vault.Tests.Extensions;
 
+/// <summary>
+/// Tests for <see cref="AzureKeyVaultHoneyDrunkBuilderExtensions"/>.
+/// </summary>
 public sealed class AzureKeyVaultHoneyDrunkBuilderExtensionsTests
 {
+    /// <summary>
+    /// Verifies that Azure providers are registered when the Key Vault URI is present.
+    /// </summary>
     [Fact]
     public void AddVaultWithAzureKeyVaultBootstrap_RegistersAzureProviders_WhenUriPresent()
     {
         var services = new ServiceCollection();
-        var configuration = new ConfigurationManager();
+        using var configuration = new ConfigurationManager();
         configuration["AZURE_KEYVAULT_URI"] = "https://kv-test.vault.azure.net/";
         services.AddSingleton<IConfiguration>(configuration);
 
@@ -28,11 +34,14 @@ public sealed class AzureKeyVaultHoneyDrunkBuilderExtensionsTests
         Assert.Contains(services, d => d.ServiceType == typeof(RegisteredConfigSourceProvider));
     }
 
+    /// <summary>
+    /// Verifies that file-based fallback providers are registered in Development when no URI is set.
+    /// </summary>
     [Fact]
     public void AddVaultWithAzureKeyVaultBootstrap_RegistersFileFallback_WhenDevelopmentAndUriMissing()
     {
         var services = new ServiceCollection();
-        var configuration = new ConfigurationManager();
+        using var configuration = new ConfigurationManager();
         configuration["ASPNETCORE_ENVIRONMENT"] = "Development";
         services.AddSingleton<IConfiguration>(configuration);
 
@@ -48,11 +57,14 @@ public sealed class AzureKeyVaultHoneyDrunkBuilderExtensionsTests
         Assert.Contains(services, d => d.ServiceType == typeof(RegisteredConfigSourceProvider));
     }
 
+    /// <summary>
+    /// Verifies that an exception is thrown when not in Development and no URI is configured.
+    /// </summary>
     [Fact]
     public void AddVaultWithAzureKeyVaultBootstrap_Throws_WhenNonDevelopmentAndUriMissing()
     {
         var services = new ServiceCollection();
-        var configuration = new ConfigurationManager();
+        using var configuration = new ConfigurationManager();
         configuration["ASPNETCORE_ENVIRONMENT"] = "Production";
         services.AddSingleton<IConfiguration>(configuration);
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensionsTests.cs
@@ -1,0 +1,70 @@
+using HoneyDrunk.Kernel.Abstractions.Hosting;
+using HoneyDrunk.Vault.Services;
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
+using HoneyDrunk.Vault.Providers.File.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+public sealed class AzureKeyVaultHoneyDrunkBuilderExtensionsTests
+{
+    [Fact]
+    public void AddVaultWithAzureKeyVaultBootstrap_RegistersAzureProviders_WhenUriPresent()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationManager();
+        configuration["AZURE_KEYVAULT_URI"] = "https://kv-test.vault.azure.net/";
+        services.AddSingleton<IConfiguration>(configuration);
+
+        var builder = CreateBuilder(services);
+
+        var result = builder.AddVaultWithAzureKeyVaultBootstrap();
+
+        Assert.Same(builder, result);
+        Assert.Contains(services, d => d.ServiceType == typeof(RegisteredSecretProvider));
+        Assert.Contains(services, d => d.ServiceType == typeof(RegisteredConfigSourceProvider));
+    }
+
+    [Fact]
+    public void AddVaultWithAzureKeyVaultBootstrap_RegistersFileFallback_WhenDevelopmentAndUriMissing()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationManager();
+        configuration["ASPNETCORE_ENVIRONMENT"] = "Development";
+        services.AddSingleton<IConfiguration>(configuration);
+
+        var builder = CreateBuilder(services);
+
+        builder.AddVaultWithAzureKeyVaultBootstrap(options =>
+        {
+            options.DevelopmentSecretsFilePath = "secrets/dev-secrets.json";
+        });
+
+        Assert.Contains(services, d => d.ServiceType == typeof(IOptions<FileVaultOptions>));
+        Assert.Contains(services, d => d.ServiceType == typeof(RegisteredSecretProvider));
+        Assert.Contains(services, d => d.ServiceType == typeof(RegisteredConfigSourceProvider));
+    }
+
+    [Fact]
+    public void AddVaultWithAzureKeyVaultBootstrap_Throws_WhenNonDevelopmentAndUriMissing()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationManager();
+        configuration["ASPNETCORE_ENVIRONMENT"] = "Production";
+        services.AddSingleton<IConfiguration>(configuration);
+
+        var builder = CreateBuilder(services);
+
+        Assert.Throws<InvalidOperationException>(() => builder.AddVaultWithAzureKeyVaultBootstrap());
+    }
+
+    private static IHoneyDrunkBuilder CreateBuilder(IServiceCollection services)
+    {
+        var builderMock = new Mock<IHoneyDrunkBuilder>();
+        builderMock.SetupGet(static b => b.Services).Returns(services);
+        return builderMock.Object;
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
@@ -31,6 +31,8 @@
     <ProjectReference Include="..\HoneyDrunk.Vault.Providers.Configuration\HoneyDrunk.Vault.Providers.Configuration.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Vault.Providers.InMemory\HoneyDrunk.Vault.Providers.InMemory.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Vault.Providers.File\HoneyDrunk.Vault.Providers.File.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Vault.Providers.AppConfiguration\HoneyDrunk.Vault.Providers.AppConfiguration.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Vault.Providers.AzureKeyVault\HoneyDrunk.Vault.Providers.AzureKeyVault.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Vault\HoneyDrunk.Vault.csproj" />
   </ItemGroup>
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.slnx
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.slnx
@@ -28,9 +28,9 @@
     <File Path="../.github/workflows/publish.yml" />
     <File Path="../.github/workflows/validate-pr.yml" />
   </Folder>
+  <Project Path="HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj" />
   <Project Path="HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj" Id="a2e5c3b1-8f4d-4e2a-9c6b-7d8e1f2a3b4c" />
   <Project Path="HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj" Id="9b1a636f-63cc-415d-b568-77217cb13573" />
-  <Project Path="HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj" />
   <Project Path="HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj" Id="4be0d3da-4d23-420a-b013-d8db47bf7604" />
   <Project Path="HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj" />
   <Project Path="HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj" Id="f5761d27-cad7-4836-bd50-2520bdadcd0e" />

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.slnx
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.slnx
@@ -30,6 +30,7 @@
   </Folder>
   <Project Path="HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj" Id="a2e5c3b1-8f4d-4e2a-9c6b-7d8e1f2a3b4c" />
   <Project Path="HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj" Id="9b1a636f-63cc-415d-b568-77217cb13573" />
+  <Project Path="HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj" />
   <Project Path="HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj" Id="4be0d3da-4d23-420a-b013-d8db47bf7604" />
   <Project Path="HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj" />
   <Project Path="HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj" Id="f5761d27-cad7-4836-bd50-2520bdadcd0e" />

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-11
+
+### Added
+- Added bootstrap extension surface across provider packages for env-var-driven Key Vault and App Configuration discovery.
+- Added `HoneyDrunk.Vault.Providers.AppConfiguration` package integration to the solution and tests.
+
 ## [0.2.0] - 2026-01-25
 
 ### Added
-- Added ADR-0005 bootstrap extension surface across provider packages for env-var-driven Key Vault and App Configuration discovery.
-- Added `HoneyDrunk.Vault.Providers.AppConfiguration` package integration to the solution and tests.
 - Architecture canary tests for enforcing Kernel context ownership invariants
 - `CanaryInvariantException` for reporting invariant violations
 - `KernelContextOwnershipInvariant` - validates context stability during Vault operations

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
@@ -5,15 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-04-11
+## [0.2.0] - 2026-01-25
 
 ### Added
 - Added ADR-0005 bootstrap extension surface across provider packages for env-var-driven Key Vault and App Configuration discovery.
 - Added `HoneyDrunk.Vault.Providers.AppConfiguration` package integration to the solution and tests.
-
-## [0.2.0] - 2026-01-25
-
-### Added
 - Architecture canary tests for enforcing Kernel context ownership invariants
 - `CanaryInvariantException` for reporting invariant violations
 - `KernelContextOwnershipInvariant` - validates context stability during Vault operations

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-11
+
+### Added
+- Added ADR-0005 bootstrap extension surface across provider packages for env-var-driven Key Vault and App Configuration discovery.
+- Added `HoneyDrunk.Vault.Providers.AppConfiguration` package integration to the solution and tests.
+
 ## [0.2.0] - 2026-01-25
 
 ### Added

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - 2026-04-11
+## [0.3.0] - 2026-04-11
 
 ### Added
 - Added bootstrap extension surface across provider packages for env-var-driven Key Vault and App Configuration discovery.

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Secrets and configuration management library for .NET. Provides a unified abstraction for accessing secrets from multiple providers (File, Azure Key Vault, AWS Secrets Manager, Configuration, In-Memory). Integrated with HoneyDrunk.Kernel for lifecycle management, health reporting, and distributed telemetry.</Description>
-    <PackageReleaseNotes>v0.2.0: Added architecture canary tests for enforcing Kernel context ownership invariants. Improved provider boundary validation. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.2.1: Added bootstrap-related provider integration updates and changelog cleanup. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;secrets;configuration;provider;cache;resilience;circuit-breaker;retry;azure-keyvault;aws;kernel;grid;distributed-tracing</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault</PackageId>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Secrets and configuration management library for .NET. Provides a unified abstraction for accessing secrets from multiple providers (File, Azure Key Vault, AWS Secrets Manager, Configuration, In-Memory). Integrated with HoneyDrunk.Kernel for lifecycle management, health reporting, and distributed telemetry.</Description>
-    <PackageReleaseNotes>v0.2.1: Added bootstrap-related provider integration updates and changelog cleanup. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Added bootstrap-related provider integration updates and changelog cleanup. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;secrets;configuration;provider;cache;resilience;circuit-breaker;retry;azure-keyvault;aws;kernel;grid;distributed-tracing</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
### Motivation
- Implement the ADR-0005 bootstrap contract so deployable Nodes can discover Key Vault and App Configuration endpoints via environment variables instead of hardcoding or deriving names. 
- Remove per-Node boilerplate by providing opt-in, provider-scoped builder extensions that wire sensible defaults (DefaultAzureCredential, label partitioning, dev fallbacks) across dev/CI/Azure.
- Keep provider packages optional so no new runtime dependency is introduced on the core `HoneyDrunk.Vault` package.

### Description
- Added an ADR-0005 Key Vault bootstrap overload in the Azure Key Vault provider package as `AddVault(this IHoneyDrunkBuilder, Action<AzureKeyVaultBootstrapOptions>?)` that reads `AZURE_KEYVAULT_URI`, uses `DefaultAzureCredential`, falls back to the File provider in Development, and throws a descriptive bootstrap exception otherwise. 
- Added a new `HoneyDrunk.Vault.Providers.AppConfiguration` package with `AddAppConfiguration(this IHoneyDrunkBuilder, Action<AppConfigurationOptions>?)` that reads `AZURE_APPCONFIG_ENDPOINT`, enforces `HONEYDRUNK_NODE_ID` for per-Node label partitioning, configures Azure App Configuration with `DefaultAzureCredential`, resolves Key Vault references with the same credential, registers `IFeatureManager`, and provides a Development fallback to `appsettings.Development.json`.
- Introduced small helper types and resolvers: `AzureKeyVaultBootstrapOptions`, `AppConfigurationOptions`, and `BootstrapConfigurationResolver` implementations for both provider packages, plus wiring in solution/project references and changelog updates.
- Added unit tests covering bootstrap resolver branches (endpoint/URI present, missing + Development detection) and updated the test project references to include the new provider package.

### Testing
- Added unit tests: `AzureKeyVaultBootstrapConfigurationResolverTests` and `AppConfigurationBootstrapConfigurationResolverTests` that verify URI/endpoint present, URI/endpoint missing, and Development detection branches. 
- Attempted to run `dotnet test HoneyDrunk.Vault/HoneyDrunk.Vault.slnx` in the rollout environment but the `dotnet` CLI is not available there, so the test run could not be executed; the tests were added but not executed in this environment. 
- Local/CI validation expected: run `dotnet test` in an environment with the .NET SDK to execute the newly added tests (should cover the three acceptance branches for each resolver).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab17f3f8483268c78459c527e7ac2)