### PR TITLE
feat(eventgrid): add Event Grid webhook cache invalidation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,11 @@ jobs:
   release:
     name: Build, Pack & Publish
     needs: prepare
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      security-events: write
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/release.yml@main
     with:
       dotnet-version: '10.0.x'

--- a/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/CHANGELOG.md
@@ -1,0 +1,57 @@
+# HoneyDrunk.Vault - Repository Changelog
+
+All notable changes to the HoneyDrunk.Vault repository will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+**Note:** See individual package CHANGELOGs for detailed changes:
+- [HoneyDrunk.Vault CHANGELOG](HoneyDrunk.Vault/CHANGELOG.md)
+- [HoneyDrunk.Vault.Providers.AzureKeyVault CHANGELOG](HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md)
+- [HoneyDrunk.Vault.Providers.Aws CHANGELOG](HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md)
+- [HoneyDrunk.Vault.Providers.Configuration CHANGELOG](HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md)
+- [HoneyDrunk.Vault.Providers.File CHANGELOG](HoneyDrunk.Vault.Providers.File/CHANGELOG.md)
+- [HoneyDrunk.Vault.Providers.InMemory CHANGELOG](HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md)
+- [HoneyDrunk.Vault.Providers.AppConfiguration CHANGELOG](HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md)
+
+---
+
+## [0.3.0] - 2026-04-11
+
+### Added
+
+- Bootstrap extension surface across provider packages for env-var-driven Key Vault and App Configuration discovery
+- `HoneyDrunk.Vault.Providers.AppConfiguration` package for Azure App Configuration integration
+- `ISecretCacheInvalidator` and explicit `SecretCache` invalidation support for rotated secrets (ADR-0006 Tier 3)
+- Optional `HoneyDrunk.Vault.EventGrid` webhook helpers for subscription validation and `SecretNewVersionCreated` cache invalidation
+
+## [0.2.0] - 2026-01-25
+
+### Added
+
+- Architecture canary tests for enforcing Kernel context ownership invariants
+- `CanaryInvariantException`, `KernelContextOwnershipInvariant`, `NoContextCreationInvariant`, `ProviderBoundaryInvariant`
+- `VaultArchitectureCanaryTests` comprehensive test suite
+
+### Changed
+
+- Tests now use full composite stack with proper provider registration
+- Improved documentation for provider slot architecture
+
+## [0.1.0] - 2025-01-01
+
+### Added
+
+- Initial release of HoneyDrunk.Vault
+- `ISecretStore` abstraction for secret access
+- `IConfigProvider` abstraction for typed configuration access
+- Multiple provider support with priority-based selection
+- `VaultClient` for orchestrating secret retrieval across providers
+- `SecretCache` for in-memory caching with configurable TTL
+- Provider slot pattern: Azure Key Vault, AWS Secrets Manager, File, InMemory, Configuration providers
+- Health, telemetry, and lifecycle integration with HoneyDrunk.Kernel
+- Resilience options (retry and circuit breaker)
+
+[0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.3.0
+[0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.2.0
+[0.1.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.1.0

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog - HoneyDrunk.Vault.EventGrid
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2026-04-12
+
+### Added
+- Initial `HoneyDrunk.Vault.EventGrid` package for ADR-0006 Tier 3 rotation propagation.
+- `VaultInvalidationWebhookHandler` for Event Grid subscription validation, webhook authentication, and cache invalidation.
+- `VaultInvalidationFunctionHandler` wrapper for Function App hosts.
+- `AddVaultEventGridInvalidation(IServiceCollection)` registration helper.
+- `MapVaultInvalidationWebhook(IEndpointRouteBuilder, string)` endpoint helper for ASP.NET Core hosts.
+- Support for Event Grid schema and CloudEvents schema payloads for `Microsoft.KeyVault.SecretNewVersionCreated`.

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Constants/VaultInvalidationWebhookConstants.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Constants/VaultInvalidationWebhookConstants.cs
@@ -1,0 +1,27 @@
+namespace HoneyDrunk.Vault.EventGrid.Constants;
+
+/// <summary>
+/// Constants for Vault Event Grid invalidation handlers.
+/// </summary>
+public static class VaultInvalidationWebhookConstants
+{
+    /// <summary>
+    /// The secret name used to look up the webhook shared secret via <c>ISecretStore</c>.
+    /// </summary>
+    public const string SharedSecretName = "VaultInvalidationWebhookSecret";
+
+    /// <summary>
+    /// The header name that carries the shared secret.
+    /// </summary>
+    public const string SharedSecretHeaderName = "X-HoneyDrunk-Vault-Webhook-Secret";
+
+    /// <summary>
+    /// The Event Grid event type for Key Vault secret version creation.
+    /// </summary>
+    public const string SecretNewVersionCreatedEventType = "Microsoft.KeyVault.SecretNewVersionCreated";
+
+    /// <summary>
+    /// The Event Grid subscription validation event type.
+    /// </summary>
+    public const string SubscriptionValidationEventType = "Microsoft.EventGrid.SubscriptionValidationEvent";
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Extensions/VaultEventGridServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Extensions/VaultEventGridServiceCollectionExtensions.cs
@@ -1,0 +1,25 @@
+using HoneyDrunk.Vault.EventGrid.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace HoneyDrunk.Vault.EventGrid.Extensions;
+
+/// <summary>
+/// Registers Vault Event Grid invalidation services.
+/// </summary>
+public static class VaultEventGridServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds reusable Event Grid invalidation handlers for ASP.NET Core and Function hosts.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The same service collection instance so additional registrations can be chained.</returns>
+    public static IServiceCollection AddVaultEventGridInvalidation(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<VaultInvalidationWebhookHandler>();
+        services.TryAddSingleton<VaultInvalidationFunctionHandler>();
+        return services;
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Extensions/VaultInvalidationEndpointRouteBuilderExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Extensions/VaultInvalidationEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,53 @@
+using HoneyDrunk.Vault.EventGrid.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HoneyDrunk.Vault.EventGrid.Extensions;
+
+/// <summary>
+/// Endpoint registration helpers for Vault invalidation webhooks.
+/// </summary>
+public static class VaultInvalidationEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps a POST webhook endpoint that validates Event Grid requests and invalidates Vault cache entries.
+    /// </summary>
+    /// <param name="endpoints">The route builder.</param>
+    /// <param name="pattern">The route pattern.</param>
+    /// <returns>The convention builder.</returns>
+    public static IEndpointConventionBuilder MapVaultInvalidationWebhook(
+        this IEndpointRouteBuilder endpoints,
+        string pattern)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentException.ThrowIfNullOrWhiteSpace(pattern);
+
+        return endpoints.MapPost(pattern, async context =>
+        {
+            var handler = context.RequestServices.GetRequiredService<VaultInvalidationWebhookHandler>();
+            var request = context.Request;
+
+            using var reader = new StreamReader(request.Body, leaveOpen: true);
+            var body = await reader.ReadToEndAsync(context.RequestAborted).ConfigureAwait(false);
+
+            var headers = request.Headers.ToDictionary(
+                pair => pair.Key,
+                pair => (string?)pair.Value.ToString(),
+                StringComparer.OrdinalIgnoreCase);
+
+            var response = await handler.HandleAsync(
+                new Models.VaultInvalidationWebhookRequest(headers, body),
+                context.RequestAborted).ConfigureAwait(false);
+
+            context.Response.StatusCode = response.StatusCode;
+
+            if (!string.IsNullOrWhiteSpace(response.Body))
+            {
+                context.Response.ContentType = response.ContentType;
+                await context.Response.WriteAsync(response.Body, context.RequestAborted).ConfigureAwait(false);
+            }
+        });
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Extensions/VaultInvalidationEndpointRouteBuilderExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Extensions/VaultInvalidationEndpointRouteBuilderExtensions.cs
@@ -11,6 +11,8 @@ namespace HoneyDrunk.Vault.EventGrid.Extensions;
 /// </summary>
 public static class VaultInvalidationEndpointRouteBuilderExtensions
 {
+    private const long MaxRequestBodyBytes = 256 * 1024;
+
     /// <summary>
     /// Maps a POST webhook endpoint that validates Event Grid requests and invalidates Vault cache entries.
     /// </summary>
@@ -29,8 +31,26 @@ public static class VaultInvalidationEndpointRouteBuilderExtensions
             var handler = context.RequestServices.GetRequiredService<VaultInvalidationWebhookHandler>();
             var request = context.Request;
 
+            if (!request.Headers.ContainsKey(Constants.VaultInvalidationWebhookConstants.SharedSecretHeaderName))
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                return;
+            }
+
+            if (request.ContentLength is > MaxRequestBodyBytes)
+            {
+                context.Response.StatusCode = StatusCodes.Status413PayloadTooLarge;
+                return;
+            }
+
             using var reader = new StreamReader(request.Body, leaveOpen: true);
             var body = await reader.ReadToEndAsync(context.RequestAborted).ConfigureAwait(false);
+
+            if (body.Length > MaxRequestBodyBytes)
+            {
+                context.Response.StatusCode = StatusCodes.Status413PayloadTooLarge;
+                return;
+            }
 
             var headers = request.Headers.ToDictionary(
                 pair => pair.Key,

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
@@ -8,32 +8,31 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NoWarn>$(NoWarn);CA1873;CA1016</NoWarn>
 
-    <!-- Package Metadata -->
-    <PackageId>HoneyDrunk.Vault.Providers.Aws</PackageId>
+    <PackageId>HoneyDrunk.Vault.EventGrid</PackageId>
     <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
-    <Description>AWS Secrets Manager provider for HoneyDrunk.Vault. Provides secure secret management using AWS Secrets Manager with support for IAM roles, access keys, and EC2 instance profiles.</Description>
-    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
-    <PackageTags>vault;provider;secrets;aws;secrets-manager;iam;access-keys;instance-profile;ec2;authentication</PackageTags>
+    <Description>Event Grid webhook helpers for HoneyDrunk.Vault cache invalidation.</Description>
+    <PackageReleaseNotes>v0.3.0: Added Event Grid cache invalidation webhook support for ADR-0006 Tier 3 rotation propagation.</PackageReleaseNotes>
+    <PackageTags>vault;eventgrid;azure;webhook;secrets;cache;rotation</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault</PackageProjectUrl>
-
-    <!-- Symbol Package Configuration -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.4.17" />
-    <PackageReference Include="AWSSDK.SSO" Version="4.0.2.24" />
-    <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.25" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Models/VaultInvalidationWebhookRequest.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Models/VaultInvalidationWebhookRequest.cs
@@ -1,0 +1,10 @@
+namespace HoneyDrunk.Vault.EventGrid.Models;
+
+/// <summary>
+/// Represents a webhook request for Vault cache invalidation.
+/// </summary>
+/// <param name="Headers">The request headers.</param>
+/// <param name="Body">The raw request body.</param>
+public sealed record VaultInvalidationWebhookRequest(
+    IReadOnlyDictionary<string, string?> Headers,
+    string Body);

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Models/VaultInvalidationWebhookResponse.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Models/VaultInvalidationWebhookResponse.cs
@@ -1,0 +1,12 @@
+namespace HoneyDrunk.Vault.EventGrid.Models;
+
+/// <summary>
+/// Represents the outcome of a Vault invalidation webhook request.
+/// </summary>
+/// <param name="StatusCode">The HTTP status code to return.</param>
+/// <param name="Body">The optional response body.</param>
+/// <param name="ContentType">The response content type.</param>
+public sealed record VaultInvalidationWebhookResponse(
+    int StatusCode,
+    string? Body = null,
+    string ContentType = "application/json");

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/README.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/README.md
@@ -1,0 +1,133 @@
+# HoneyDrunk.Vault.EventGrid
+
+Azure Event Grid webhook helpers for `HoneyDrunk.Vault`. This package wires Key Vault rotation events into `SecretCache` invalidation so running workloads refresh rotated secrets within seconds instead of waiting on TTL.
+
+## Overview
+
+This package is the transport glue for ADR-0006 Tier 3 rotation propagation. It is designed for hosts that already use `HoneyDrunk.Vault` and need to receive Azure Event Grid events raised by Azure Key Vault, validate the subscription handshake, authenticate inbound webhook requests, and invalidate cached secret names through `ISecretCacheInvalidator`.
+
+**Features:**
+- Parses `Microsoft.KeyVault.SecretNewVersionCreated`
+- Accepts Event Grid schema and CloudEvents schema payloads
+- Handles Event Grid subscription validation handshake
+- Authenticates webhook requests with a shared secret resolved from `ISecretStore`
+- Exposes ASP.NET Core endpoint mapping helpers
+- Exposes a Functions-friendly handler wrapper
+- Never logs secret values, only secret names
+
+## Installation
+
+```bash
+dotnet add package HoneyDrunk.Vault
+dotnet add package HoneyDrunk.Vault.EventGrid
+```
+
+## Prerequisites
+
+- Azure Key Vault configured to emit Event Grid events
+- An Azure Event Grid subscription targeting your application webhook
+- `HoneyDrunk.Vault` configured with a provider capable of resolving `VaultInvalidationWebhookSecret`
+- A host application using ASP.NET Core or Azure Functions
+
+## Quick Start
+
+### ASP.NET Core Minimal API
+
+```csharp
+using HoneyDrunk.Vault.EventGrid.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddVault(...);
+builder.Services.AddVaultEventGridInvalidation();
+
+var app = builder.Build();
+app.MapVaultInvalidationWebhook("/internal/vault/invalidate");
+app.Run();
+```
+
+### Azure Functions Friendly Wrapper
+
+```csharp
+public sealed class VaultInvalidationFunction
+{
+    private readonly VaultInvalidationFunctionHandler _handler;
+
+    public VaultInvalidationFunction(VaultInvalidationFunctionHandler handler)
+    {
+        _handler = handler;
+    }
+
+    public Task<VaultInvalidationWebhookResponse> RunAsync(
+        IReadOnlyDictionary<string, string?> headers,
+        string body,
+        CancellationToken cancellationToken)
+    {
+        return _handler.HandleAsync(headers, body, cancellationToken);
+    }
+}
+```
+
+## Authentication Model
+
+Requests are authenticated by:
+
+1. Event Grid origin and subscription validation flow
+2. A shared secret header, `X-HoneyDrunk-Vault-Webhook-Secret`
+
+The expected shared secret value is not hardcoded and is not read from an environment variable. It is resolved from `ISecretStore` using the secret name `VaultInvalidationWebhookSecret`.
+
+## Event Handling
+
+For `Microsoft.KeyVault.SecretNewVersionCreated`, the handler reads `objectName` from the event payload and calls `ISecretCacheInvalidator.Invalidate(secretName)`.
+
+That means:
+- the cache entry for that secret name is removed
+- the next `ISecretStore.GetSecretAsync(new SecretIdentifier(name))` call fetches from the provider
+- callers continue resolving the latest version without pinning, preserving invariant 21
+
+## Example Event Shapes
+
+### Event Grid Schema
+
+```json
+[
+  {
+    "eventType": "Microsoft.KeyVault.SecretNewVersionCreated",
+    "data": {
+      "objectName": "DbPassword"
+    }
+  }
+]
+```
+
+### CloudEvents Schema
+
+```json
+[
+  {
+    "type": "Microsoft.KeyVault.SecretNewVersionCreated",
+    "data": {
+      "objectName": "DbPassword"
+    }
+  }
+]
+```
+
+## Best Practices
+
+1. Keep the webhook endpoint internal or network-restricted where possible.
+2. Store `VaultInvalidationWebhookSecret` in the same secure Vault system as other application secrets.
+3. Do not pin applications to a secret version when relying on cache invalidation.
+4. Treat cache TTL as a fallback safety net, not the primary propagation mechanism.
+5. Log only secret names and operational status, never secret values.
+
+## Related Packages
+
+- [HoneyDrunk.Vault](../HoneyDrunk.Vault)
+- [HoneyDrunk.Vault.Providers.AzureKeyVault](../HoneyDrunk.Vault.Providers.AzureKeyVault)
+- [HoneyDrunk.Vault.Providers.AppConfiguration](../HoneyDrunk.Vault.Providers.AppConfiguration)
+
+## License
+
+MIT License

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Services/VaultInvalidationFunctionHandler.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Services/VaultInvalidationFunctionHandler.cs
@@ -1,0 +1,28 @@
+using HoneyDrunk.Vault.EventGrid.Models;
+
+namespace HoneyDrunk.Vault.EventGrid.Services;
+
+/// <summary>
+/// Functions-friendly wrapper around <see cref="VaultInvalidationWebhookHandler"/>.
+/// </summary>
+public sealed class VaultInvalidationFunctionHandler(VaultInvalidationWebhookHandler handler)
+{
+    private readonly VaultInvalidationWebhookHandler _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+
+    /// <summary>
+    /// Handles a Function-hosted Event Grid webhook request.
+    /// </summary>
+    /// <param name="headers">The request headers.</param>
+    /// <param name="body">The raw request body.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The webhook response.</returns>
+    public Task<VaultInvalidationWebhookResponse> HandleAsync(
+        IReadOnlyDictionary<string, string?> headers,
+        string body,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(headers);
+
+        return _handler.HandleAsync(new VaultInvalidationWebhookRequest(headers, body), cancellationToken);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Services/VaultInvalidationWebhookHandler.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/Services/VaultInvalidationWebhookHandler.cs
@@ -1,0 +1,265 @@
+using Azure.Messaging;
+using Azure.Messaging.EventGrid;
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.EventGrid.Constants;
+using HoneyDrunk.Vault.EventGrid.Models;
+using HoneyDrunk.Vault.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace HoneyDrunk.Vault.EventGrid.Services;
+
+/// <summary>
+/// Handles Event Grid webhook requests that invalidate <see cref="ISecretCacheInvalidator"/> entries.
+/// This supports ADR-0006 Tier 3 and preserves invariant 21 by forcing the next read to resolve latest.
+/// </summary>
+public sealed class VaultInvalidationWebhookHandler(
+    ISecretStore secretStore,
+    ISecretCacheInvalidator cacheInvalidator,
+    ILogger<VaultInvalidationWebhookHandler> logger)
+{
+    private readonly ISecretStore _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+    private readonly ISecretCacheInvalidator _cacheInvalidator = cacheInvalidator ?? throw new ArgumentNullException(nameof(cacheInvalidator));
+    private readonly ILogger<VaultInvalidationWebhookHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    /// <summary>
+    /// Handles an Event Grid webhook request.
+    /// </summary>
+    /// <param name="request">The webhook request.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The webhook response.</returns>
+    public async Task<VaultInvalidationWebhookResponse> HandleAsync(
+        VaultInvalidationWebhookRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!await IsAuthenticatedAsync(request.Headers, cancellationToken).ConfigureAwait(false))
+        {
+            _logger.LogWarning("Rejected Vault invalidation webhook request due to invalid authentication");
+            return new VaultInvalidationWebhookResponse(StatusCodes.Status401Unauthorized);
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Body))
+        {
+            return new VaultInvalidationWebhookResponse(StatusCodes.Status400BadRequest);
+        }
+
+        var body = BinaryData.FromString(request.Body);
+
+        if (TryParseEventGridEvents(body, out var eventGridEvents))
+        {
+            return HandleEventGridEvents(eventGridEvents);
+        }
+
+        if (TryParseCloudEvents(body, out var cloudEvents))
+        {
+            return HandleCloudEvents(cloudEvents);
+        }
+
+        return new VaultInvalidationWebhookResponse(StatusCodes.Status400BadRequest);
+    }
+
+    private static bool FixedTimeEquals(string expected, string provided)
+    {
+        var expectedBytes = Encoding.UTF8.GetBytes(expected);
+        var providedBytes = Encoding.UTF8.GetBytes(provided);
+        return CryptographicOperations.FixedTimeEquals(expectedBytes, providedBytes);
+    }
+
+    private static bool TryParseCloudEvents(BinaryData body, out CloudEvent[] cloudEvents)
+    {
+        try
+        {
+            cloudEvents = body.ToObjectFromJson<CloudEvent[]>() ?? [];
+            return cloudEvents.Length > 0;
+        }
+        catch
+        {
+            cloudEvents = [];
+            return false;
+        }
+    }
+
+    private static bool TryParseEventGridEvents(BinaryData body, out EventGridEvent[] eventGridEvents)
+    {
+        try
+        {
+            eventGridEvents = EventGridEvent.ParseMany(body);
+            return eventGridEvents.Length > 0;
+        }
+        catch
+        {
+            eventGridEvents = [];
+            return false;
+        }
+    }
+
+    private static bool TryGetHeader(
+        IReadOnlyDictionary<string, string?> headers,
+        string key,
+        out string? value)
+    {
+        foreach (var pair in headers)
+        {
+            if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = pair.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static VaultInvalidationWebhookResponse BuildInvalidationResponse(int invalidatedCount)
+    {
+        return new VaultInvalidationWebhookResponse(
+            StatusCodes.Status200OK,
+            $$"""{"invalidated":{{invalidatedCount}}}""");
+    }
+
+    private static VaultInvalidationWebhookResponse BuildValidationResponse(string validationCode)
+    {
+        return new VaultInvalidationWebhookResponse(
+            StatusCodes.Status200OK,
+            $$"""{"validationResponse":"{{validationCode}}"}""");
+    }
+
+    private static string? TryGetSecretName(CloudEvent cloudEvent)
+    {
+        if (!string.Equals(
+            cloudEvent.Type,
+            VaultInvalidationWebhookConstants.SecretNewVersionCreatedEventType,
+            StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return TryGetDataString(cloudEvent.Data, "objectName");
+    }
+
+    private static string? TryGetSecretName(EventGridEvent eventGridEvent)
+    {
+        if (!string.Equals(
+            eventGridEvent.EventType,
+            VaultInvalidationWebhookConstants.SecretNewVersionCreatedEventType,
+            StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return TryGetDataString(eventGridEvent.Data, "objectName");
+    }
+
+    private static string? TryGetValidationCode(BinaryData? data)
+    {
+        return TryGetDataString(data, "validationCode");
+    }
+
+    private static string? TryGetDataString(BinaryData? data, string propertyName)
+    {
+        if (data == null)
+        {
+            return null;
+        }
+
+        using var document = JsonDocument.Parse(data);
+        return document.RootElement.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+    }
+
+    private async Task<bool> IsAuthenticatedAsync(
+        IReadOnlyDictionary<string, string?> headers,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetHeader(headers, VaultInvalidationWebhookConstants.SharedSecretHeaderName, out var providedSecret) ||
+            string.IsNullOrEmpty(providedSecret))
+        {
+            return false;
+        }
+
+        var expectedSecretResult = await _secretStore.TryGetSecretAsync(
+            new SecretIdentifier(VaultInvalidationWebhookConstants.SharedSecretName),
+            cancellationToken).ConfigureAwait(false);
+
+        if (!expectedSecretResult.IsSuccess || expectedSecretResult.Value == null)
+        {
+            _logger.LogWarning(
+                "Vault invalidation webhook secret '{SecretName}' is not configured",
+                VaultInvalidationWebhookConstants.SharedSecretName);
+            return false;
+        }
+
+        return FixedTimeEquals(expectedSecretResult.Value.Value, providedSecret);
+    }
+
+    private VaultInvalidationWebhookResponse HandleCloudEvents(IEnumerable<CloudEvent> cloudEvents)
+    {
+        var invalidatedCount = 0;
+        foreach (var cloudEvent in cloudEvents)
+        {
+            if (string.Equals(
+                cloudEvent.Type,
+                VaultInvalidationWebhookConstants.SubscriptionValidationEventType,
+                StringComparison.Ordinal))
+            {
+                var validationCode = TryGetValidationCode(cloudEvent.Data);
+                if (!string.IsNullOrWhiteSpace(validationCode))
+                {
+                    _logger.LogInformation("Completed Event Grid subscription validation handshake");
+                    return BuildValidationResponse(validationCode);
+                }
+            }
+
+            var secretName = TryGetSecretName(cloudEvent);
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                continue;
+            }
+
+            _cacheInvalidator.Invalidate(secretName);
+            invalidatedCount++;
+            _logger.LogInformation("Invalidated Vault cache for secret '{SecretName}'", secretName);
+        }
+
+        return BuildInvalidationResponse(invalidatedCount);
+    }
+
+    private VaultInvalidationWebhookResponse HandleEventGridEvents(IEnumerable<EventGridEvent> eventGridEvents)
+    {
+        var invalidatedCount = 0;
+        foreach (var eventGridEvent in eventGridEvents)
+        {
+            if (string.Equals(
+                eventGridEvent.EventType,
+                VaultInvalidationWebhookConstants.SubscriptionValidationEventType,
+                StringComparison.Ordinal))
+            {
+                var validationCode = TryGetValidationCode(eventGridEvent.Data);
+                if (!string.IsNullOrWhiteSpace(validationCode))
+                {
+                    _logger.LogInformation("Completed Event Grid subscription validation handshake");
+                    return BuildValidationResponse(validationCode);
+                }
+            }
+
+            var secretName = TryGetSecretName(eventGridEvent);
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                continue;
+            }
+
+            _cacheInvalidator.Invalidate(secretName);
+            invalidatedCount++;
+            _logger.LogInformation("Invalidated Vault cache for secret '{SecretName}'", secretName);
+        }
+
+        return BuildInvalidationResponse(invalidatedCount);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -25,15 +25,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.17.1" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -27,9 +27,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.17.1" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
@@ -27,12 +27,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.2" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/EventGrid/VaultInvalidationWebhookHandlerTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/EventGrid/VaultInvalidationWebhookHandlerTests.cs
@@ -1,0 +1,274 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.EventGrid.Constants;
+using HoneyDrunk.Vault.EventGrid.Models;
+using HoneyDrunk.Vault.EventGrid.Services;
+using HoneyDrunk.Vault.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace HoneyDrunk.Vault.Tests.EventGrid;
+
+/// <summary>
+/// Tests for <see cref="VaultInvalidationWebhookHandler"/>.
+/// </summary>
+public sealed class VaultInvalidationWebhookHandlerTests
+{
+    /// <summary>
+    /// Verifies that unauthenticated webhook requests are rejected.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task HandleAsync_ReturnsUnauthorized_WhenSharedSecretIsMissing()
+    {
+        // Arrange
+        var invalidator = new RecordingSecretCacheInvalidator();
+        var handler = CreateHandler(invalidator, new SharedSecretStore());
+
+        // Act
+        var response = await handler.HandleAsync(new VaultInvalidationWebhookRequest(
+            new Dictionary<string, string?>(),
+            "[]"));
+
+        // Assert
+        Assert.Equal(401, response.StatusCode);
+        Assert.Empty(invalidator.InvalidatedSecrets);
+    }
+
+    /// <summary>
+    /// Verifies that requests with the wrong shared secret are rejected.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task HandleAsync_ReturnsUnauthorized_WhenSharedSecretIsWrong()
+    {
+        // Arrange
+        var invalidator = new RecordingSecretCacheInvalidator();
+        var handler = CreateHandler(invalidator, new SharedSecretStore());
+        var request = new VaultInvalidationWebhookRequest(
+            new Dictionary<string, string?>
+            {
+                [VaultInvalidationWebhookConstants.SharedSecretHeaderName] = "wrong-secret",
+            },
+            "[]");
+
+        // Act
+        var response = await handler.HandleAsync(request);
+
+        // Assert
+        Assert.Equal(401, response.StatusCode);
+        Assert.Empty(invalidator.InvalidatedSecrets);
+    }
+
+    /// <summary>
+    /// Verifies that requests are rejected when the shared secret is not configured in Vault.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task HandleAsync_ReturnsUnauthorized_WhenSharedSecretIsNotConfigured()
+    {
+        // Arrange
+        var invalidator = new RecordingSecretCacheInvalidator();
+        var handler = CreateHandler(invalidator, new MissingSharedSecretStore());
+        var request = new VaultInvalidationWebhookRequest(
+            CreateHeaders(),
+            "[]");
+
+        // Act
+        var response = await handler.HandleAsync(request);
+
+        // Assert
+        Assert.Equal(401, response.StatusCode);
+        Assert.Empty(invalidator.InvalidatedSecrets);
+    }
+
+    /// <summary>
+    /// Verifies that the Event Grid validation handshake returns the validation code.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task HandleAsync_ReturnsValidationResponse_ForSubscriptionValidationHandshake()
+    {
+        // Arrange
+        var handler = CreateHandler(new RecordingSecretCacheInvalidator(), new SharedSecretStore());
+        const string requestBody =
+            """
+            [
+              {
+                "id": "evt-validation-1",
+                "eventType": "Microsoft.EventGrid.SubscriptionValidationEvent",
+                "subject": "",
+                "eventTime": "2026-04-12T12:00:00Z",
+                "data": {
+                  "validationCode": "abc123"
+                },
+                "dataVersion": "1",
+                "metadataVersion": "1"
+              }
+            ]
+            """;
+        var request = new VaultInvalidationWebhookRequest(
+            CreateHeaders(),
+            requestBody);
+
+        // Act
+        var response = await handler.HandleAsync(request);
+
+        // Assert
+        Assert.Equal(200, response.StatusCode);
+        Assert.NotNull(response.Body);
+        Assert.Contains("validationResponse", response.Body, StringComparison.Ordinal);
+        Assert.Contains("abc123", response.Body, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that legacy Event Grid schema events invalidate the named secret.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task HandleAsync_InvalidatesSecret_ForLegacyEventGridSchema()
+    {
+        // Arrange
+        var invalidator = new RecordingSecretCacheInvalidator();
+        var handler = CreateHandler(invalidator, new SharedSecretStore());
+        const string requestBody =
+            """
+            [
+              {
+                "id": "evt-secret-1",
+                "eventType": "Microsoft.KeyVault.SecretNewVersionCreated",
+                "subject": "DbPassword",
+                "eventTime": "2026-04-12T12:00:00Z",
+                "data": {
+                  "id": "https://vault.vault.azure.net/secrets/DbPassword/version1",
+                  "vaultName": "vault",
+                  "objectType": "Secret",
+                  "objectName": "DbPassword"
+                },
+                "dataVersion": "1",
+                "metadataVersion": "1"
+              }
+            ]
+            """;
+        var request = new VaultInvalidationWebhookRequest(
+            CreateHeaders(),
+            requestBody);
+
+        // Act
+        var response = await handler.HandleAsync(request);
+
+        // Assert
+        Assert.Equal(200, response.StatusCode);
+        Assert.Single(invalidator.InvalidatedSecrets);
+        Assert.Equal("DbPassword", invalidator.InvalidatedSecrets[0]);
+    }
+
+    /// <summary>
+    /// Verifies that CloudEvents schema events invalidate the named secret.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task HandleAsync_InvalidatesSecret_ForCloudEventsSchema()
+    {
+        // Arrange
+        var invalidator = new RecordingSecretCacheInvalidator();
+        var handler = CreateHandler(invalidator, new SharedSecretStore());
+        const string requestBody =
+            """
+            [
+              {
+                "id": "evt-cloud-1",
+                "source": "/subscriptions/test/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/vault",
+                "type": "Microsoft.KeyVault.SecretNewVersionCreated",
+                "specversion": "1.0",
+                "data": {
+                  "id": "https://vault.vault.azure.net/secrets/ApiKey/version1",
+                  "vaultName": "vault",
+                  "objectType": "Secret",
+                  "objectName": "ApiKey"
+                }
+              }
+            ]
+            """;
+        var request = new VaultInvalidationWebhookRequest(
+            CreateHeaders(),
+            requestBody);
+
+        // Act
+        var response = await handler.HandleAsync(request);
+
+        // Assert
+        Assert.Equal(200, response.StatusCode);
+        Assert.Single(invalidator.InvalidatedSecrets);
+        Assert.Equal("ApiKey", invalidator.InvalidatedSecrets[0]);
+    }
+
+    private static VaultInvalidationWebhookHandler CreateHandler(
+        RecordingSecretCacheInvalidator invalidator,
+        ISecretStore secretStore)
+    {
+        return new VaultInvalidationWebhookHandler(
+            secretStore,
+            invalidator,
+            NullLogger<VaultInvalidationWebhookHandler>.Instance);
+    }
+
+    private static Dictionary<string, string?> CreateHeaders()
+    {
+        return new Dictionary<string, string?>
+        {
+            [VaultInvalidationWebhookConstants.SharedSecretHeaderName] = SharedSecretStore.SharedSecretValue,
+        };
+    }
+
+    private sealed class RecordingSecretCacheInvalidator : ISecretCacheInvalidator
+    {
+        public List<string> InvalidatedSecrets { get; } = [];
+
+        public void Invalidate(string secretName)
+        {
+            InvalidatedSecrets.Add(secretName);
+        }
+
+        public void InvalidateAll()
+        {
+            InvalidatedSecrets.Add("*");
+        }
+    }
+
+    private sealed class SharedSecretStore : ISecretStore
+    {
+        public const string SharedSecretValue = "expected-shared-secret";
+
+        public Task<SecretValue> GetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new SecretValue(identifier, SharedSecretValue, "v1"));
+        }
+
+        public Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(VaultResult.Success(new SecretValue(identifier, SharedSecretValue, "v1")));
+        }
+
+        public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<SecretVersion>>([]);
+        }
+    }
+
+    private sealed class MissingSharedSecretStore : ISecretStore
+    {
+        public Task<SecretValue> GetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException("The handler should use TryGetSecretAsync for webhook secret lookup.");
+        }
+
+        public Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(VaultResult.Failure<SecretValue>("Secret not found"));
+        }
+
+        public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<SecretVersion>>([]);
+        }
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/VaultServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/VaultServiceCollectionExtensionsTests.cs
@@ -1,0 +1,43 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Configuration;
+using HoneyDrunk.Vault.Extensions;
+using HoneyDrunk.Vault.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="VaultServiceCollectionExtensions"/>.
+/// </summary>
+public sealed class VaultServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Verifies that AddVaultCore registers the cache invalidator alongside the cache.
+    /// </summary>
+    [Fact]
+    public void AddVaultCore_RegistersCacheInvalidatorAsSecretCache()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IOptions<VaultOptions>>(Options.Create(new VaultOptions
+        {
+            Cache = new VaultCacheOptions
+            {
+                Enabled = true,
+                DefaultTtl = TimeSpan.FromMinutes(5),
+                MaxSize = 100,
+            },
+        }));
+
+        // Act
+        services.AddVaultCore();
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        var cache = provider.GetRequiredService<SecretCache>();
+        var invalidator = provider.GetRequiredService<ISecretCacheInvalidator>();
+        Assert.Same(cache, invalidator);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
@@ -11,14 +11,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.4.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -33,6 +36,7 @@
     <ProjectReference Include="..\HoneyDrunk.Vault.Providers.File\HoneyDrunk.Vault.Providers.File.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Vault.Providers.AppConfiguration\HoneyDrunk.Vault.Providers.AppConfiguration.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Vault.Providers.AzureKeyVault\HoneyDrunk.Vault.Providers.AzureKeyVault.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Vault.EventGrid\HoneyDrunk.Vault.EventGrid.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Vault\HoneyDrunk.Vault.csproj" />
   </ItemGroup>
 
@@ -41,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
 </Project>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/CachingSecretStoreTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/CachingSecretStoreTests.cs
@@ -1,0 +1,87 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Configuration;
+using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Vault.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="CachingSecretStore"/>.
+/// </summary>
+public sealed class CachingSecretStoreTests : IDisposable
+{
+    private readonly SecretCache _cache;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachingSecretStoreTests"/> class.
+    /// </summary>
+    public CachingSecretStoreTests()
+    {
+        _cache = new SecretCache(
+            Options.Create(new VaultOptions
+            {
+                Cache = new VaultCacheOptions
+                {
+                    Enabled = true,
+                    DefaultTtl = TimeSpan.FromMinutes(5),
+                    MaxSize = 100,
+                },
+            }),
+            NullLogger<SecretCache>.Instance);
+    }
+
+    /// <summary>
+    /// Verifies that invalidating the cache forces the next read to refetch from the provider.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task GetSecretAsync_RefetchesAfterInvalidation()
+    {
+        // Arrange
+        var spyStore = new SpySecretStore();
+        var store = new CachingSecretStore(spyStore, _cache, NullLogger<CachingSecretStore>.Instance);
+        var identifier = new SecretIdentifier("db-password");
+
+        // Act
+        var first = await store.GetSecretAsync(identifier);
+        var second = await store.GetSecretAsync(identifier);
+        _cache.Invalidate(identifier.Name);
+        var third = await store.GetSecretAsync(identifier);
+
+        // Assert
+        Assert.Equal(2, spyStore.GetSecretAsyncCallCount);
+        Assert.Equal(first.Value, second.Value);
+        Assert.NotEqual(second.Value, third.Value);
+    }
+
+    /// <summary>
+    /// Disposes shared resources.
+    /// </summary>
+    public void Dispose()
+    {
+        _cache.Dispose();
+    }
+
+    private sealed class SpySecretStore : ISecretStore
+    {
+        public int GetSecretAsyncCallCount { get; private set; }
+
+        public Task<SecretValue> GetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
+        {
+            GetSecretAsyncCallCount++;
+            return Task.FromResult(new SecretValue(identifier, $"value-{GetSecretAsyncCallCount}", $"v{GetSecretAsyncCallCount}"));
+        }
+
+        public Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(VaultResult.Success(new SecretValue(identifier, "value", "v1")));
+        }
+
+        public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<SecretVersion>>([]);
+        }
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/SecretCacheTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/SecretCacheTests.cs
@@ -142,6 +142,45 @@ public sealed class SecretCacheTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies that invalidating one secret leaves other entries intact.
+    /// </summary>
+    [Fact]
+    public void Invalidate_RemovesOnlyRequestedEntry()
+    {
+        // Arrange
+        var first = new SecretValue(new SecretIdentifier("first-secret"), "first-value", "v1");
+        var second = new SecretValue(new SecretIdentifier("second-secret"), "second-value", "v1");
+        _cache.Set("first-secret", first);
+        _cache.Set("second-secret", second);
+
+        // Act
+        _cache.Invalidate("first-secret");
+
+        // Assert
+        Assert.False(_cache.TryGet("first-secret", out _));
+        Assert.True(_cache.TryGet("second-secret", out var remaining));
+        Assert.Equal("second-value", remaining!.Value);
+    }
+
+    /// <summary>
+    /// Verifies that invalidating all secrets clears the cache.
+    /// </summary>
+    [Fact]
+    public void InvalidateAll_ClearsCache()
+    {
+        // Arrange
+        _cache.Set("first-secret", new SecretValue(new SecretIdentifier("first-secret"), "first-value", "v1"));
+        _cache.Set("second-secret", new SecretValue(new SecretIdentifier("second-secret"), "second-value", "v1"));
+
+        // Act
+        _cache.InvalidateAll();
+
+        // Assert
+        Assert.False(_cache.TryGet("first-secret", out _));
+        Assert.False(_cache.TryGet("second-secret", out _));
+    }
+
+    /// <summary>
     /// Disposes of resources.
     /// </summary>
     public void Dispose()

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.slnx
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/Docs/">
     <File Path="../README.md" />
+    <File Path="CHANGELOG.md" />
   </Folder>
   <Folder Name="/Docs/Copilot/">
     <File Path="../.github/copilot-instructions.md" />
@@ -28,7 +29,10 @@
     <File Path="../.github/workflows/publish.yml" />
     <File Path="../.github/workflows/validate-pr.yml" />
   </Folder>
-  <Project Path="HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj" />
+  <Project Path="HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj" />
+  <Project Path="HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj">
+    <Build Solution="Debug|*" Project="false" />
+  </Project>
   <Project Path="HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj" Id="a2e5c3b1-8f4d-4e2a-9c6b-7d8e1f2a3b4c" />
   <Project Path="HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj" Id="9b1a636f-63cc-415d-b568-77217cb13573" />
   <Project Path="HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj" Id="4be0d3da-4d23-420a-b013-d8db47bf7604" />

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Abstractions/ISecretCacheInvalidator.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Abstractions/ISecretCacheInvalidator.cs
@@ -1,0 +1,19 @@
+namespace HoneyDrunk.Vault.Abstractions;
+
+/// <summary>
+/// Invalidates cached secret entries so rotated secrets can propagate within seconds per ADR-0006 Tier 3.
+/// This contract exists to uphold invariant 21 by keeping callers pinned to latest-version secret resolution.
+/// </summary>
+public interface ISecretCacheInvalidator
+{
+    /// <summary>
+    /// Invalidates the cached entry for the specified secret name.
+    /// </summary>
+    /// <param name="secretName">The secret name to invalidate.</param>
+    void Invalidate(string secretName);
+
+    /// <summary>
+    /// Invalidates all cached secret entries.
+    /// </summary>
+    void InvalidateAll();
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added bootstrap extension surface across provider packages for env-var-driven Key Vault and App Configuration discovery.
 - Added `HoneyDrunk.Vault.Providers.AppConfiguration` package integration to the solution and tests.
+- Added `ISecretCacheInvalidator` and explicit `SecretCache` invalidation support so rotated secrets can propagate independently of TTL per ADR-0006 Tier 3.
+- Added optional `HoneyDrunk.Vault.EventGrid` webhook helpers for Event Grid subscription validation, shared-secret auth, and `SecretNewVersionCreated` cache invalidation.
 
 ## [0.2.0] - 2026-01-25
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Extensions/HoneyDrunkBuilderExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Extensions/HoneyDrunkBuilderExtensions.cs
@@ -3,7 +3,6 @@ using HoneyDrunk.Kernel.Abstractions.Lifecycle;
 using HoneyDrunk.Vault.Configuration;
 using HoneyDrunk.Vault.Health;
 using HoneyDrunk.Vault.Lifecycle;
-using HoneyDrunk.Vault.Services;
 using HoneyDrunk.Vault.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -36,9 +35,6 @@ public static class HoneyDrunkBuilderExtensions
         var options = new VaultOptions();
         configure(options);
         services.AddSingleton(Microsoft.Extensions.Options.Options.Create(options));
-
-        // Register secret cache (always registered, respects Enabled flag internally)
-        services.TryAddSingleton<SecretCache>();
 
         // Register telemetry
         if (options.EnableTelemetry)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Extensions/VaultServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Extensions/VaultServiceCollectionExtensions.cs
@@ -32,6 +32,10 @@ public static class VaultServiceCollectionExtensions
             return new ResiliencePipelineFactory(options.Value.Resilience, logger);
         });
 
+        // Register cache + invalidation contract so webhook hosts can resolve explicit invalidation without cache internals.
+        services.TryAddSingleton<SecretCache>();
+        services.TryAddSingleton<ISecretCacheInvalidator>(sp => sp.GetRequiredService<SecretCache>());
+
         // Register composite secret store (wraps all registered providers)
         services.TryAddSingleton<CompositeSecretStore>();
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
@@ -29,17 +29,17 @@
   <ItemGroup>
     <PackageReference Include="HoneyDrunk.Kernel" Version="0.4.0" />
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.6">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Resilience" Version="10.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Resilience" Version="10.4.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" />
+    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.201" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/CachingSecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/CachingSecretStore.cs
@@ -85,7 +85,7 @@ public sealed class CachingSecretStore(
         ArgumentNullException.ThrowIfNull(identifier);
 
         var cacheKey = BuildCacheKey(identifier);
-        _cache.Remove(cacheKey);
+        _cache.Invalidate(cacheKey);
         _logger.LogDebug("Invalidated cache for secret '{SecretName}'", identifier.Name);
     }
 
@@ -94,7 +94,7 @@ public sealed class CachingSecretStore(
     /// </summary>
     public void ClearCache()
     {
-        _cache.Clear();
+        _cache.InvalidateAll();
         _logger.LogInformation("Cleared all cached secrets");
     }
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/SecretCache.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/SecretCache.cs
@@ -1,3 +1,4 @@
+using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Configuration;
 using HoneyDrunk.Vault.Models;
 using Microsoft.Extensions.Caching.Memory;
@@ -8,8 +9,9 @@ namespace HoneyDrunk.Vault.Services;
 
 /// <summary>
 /// Provides caching for secret values with configurable TTL and max size.
+/// Supports explicit invalidation so ADR-0006 Tier 3 Event Grid notifications can demote TTL to a fallback path.
 /// </summary>
-public sealed class SecretCache : IDisposable
+public sealed class SecretCache : ISecretCacheInvalidator, IDisposable
 {
     private readonly MemoryCache _cache;
     private readonly VaultCacheOptions _options;
@@ -159,14 +161,36 @@ public sealed class SecretCache : IDisposable
     }
 
     /// <summary>
+    /// Invalidates the cached entry for the specified secret name.
+    /// This preserves invariant 21 by ensuring the next latest-version read rehydrates from the backing provider.
+    /// </summary>
+    /// <param name="secretName">The secret name.</param>
+    public void Invalidate(string secretName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(secretName);
+
+        var cacheKey = BuildCacheKey(secretName);
+        _cache.Remove(cacheKey);
+        _logger.LogDebug("Invalidated cached secret '{SecretName}'", secretName);
+    }
+
+    /// <summary>
+    /// Invalidates all cached secrets.
+    /// </summary>
+    public void InvalidateAll()
+    {
+        _cache.Compact(1.0);
+        _currentCount = 0;
+        _logger.LogInformation("Invalidated all cached secrets");
+    }
+
+    /// <summary>
     /// Removes a secret from the cache.
     /// </summary>
     /// <param name="key">The cache key.</param>
     public void Remove(string key)
     {
-        var cacheKey = BuildCacheKey(key);
-        _cache.Remove(cacheKey);
-        _logger.LogDebug("Removed secret '{Key}' from cache", key);
+        Invalidate(key);
     }
 
     /// <summary>
@@ -174,9 +198,7 @@ public sealed class SecretCache : IDisposable
     /// </summary>
     public void Clear()
     {
-        _cache.Compact(1.0);
-        _currentCount = 0;
-        _logger.LogInformation("Cleared all cached secrets");
+        InvalidateAll();
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ dotnet add package HoneyDrunk.Vault.Providers.AzureKeyVault     # For Azure
 dotnet add package HoneyDrunk.Vault.Providers.Aws               # For AWS
 dotnet add package HoneyDrunk.Vault.Providers.InMemory          # For testing
 dotnet add package HoneyDrunk.Vault.Providers.Configuration     # Bridge to IConfiguration
+dotnet add package HoneyDrunk.Vault.EventGrid                   # Azure Event Grid webhook invalidation
 ```
 
 ## Quick Start
@@ -356,7 +357,8 @@ Providers (Separate Packages)
 ├── HoneyDrunk.Vault.Providers.AzureKeyVault
 ├── HoneyDrunk.Vault.Providers.Aws
 ├── HoneyDrunk.Vault.Providers.InMemory
-└── HoneyDrunk.Vault.Providers.Configuration
+├── HoneyDrunk.Vault.Providers.Configuration
+└── HoneyDrunk.Vault.EventGrid
 ```
 
 ## Documentation


### PR DESCRIPTION
Introduce HoneyDrunk.Vault.EventGrid package for ADR-0006 Tier 3 rotation propagation. Add ISecretCacheInvalidator interface and explicit cache invalidation to core. Implement webhook handler for secure, shared-secret-authenticated cache invalidation via Event Grid and CloudEvents schemas. Provide ASP.NET Core and Functions integration, new tests, and updated documentation. Update dependencies and refactor cache registration for consistency.