### PR TITLE
ci(pipelines): rename weekly-deps workflow, align slnx config

### DIFF
--- a/.github/workflows/weekly-deps.yml
+++ b/.github/workflows/weekly-deps.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   weekly-deps:

--- a/.github/workflows/weekly-deps.yml
+++ b/.github/workflows/weekly-deps.yml
@@ -1,13 +1,17 @@
-name: Nightly Dependencies
+name: Weekly Dependencies
 
 on:
   schedule:
     - cron: '0 3 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  nightly-deps:
-    name: Nightly Dependencies
+  weekly-deps:
+    name: Weekly Dependencies
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main
     with:
       check-dotnet-deps: true

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.slnx
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.slnx
@@ -30,9 +30,7 @@
     <File Path="../.github/workflows/validate-pr.yml" />
   </Folder>
   <Project Path="HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj" />
-  <Project Path="HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj">
-    <Build Solution="Debug|*" Project="false" />
-  </Project>
+  <Project Path="HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj" />
   <Project Path="HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj" Id="a2e5c3b1-8f4d-4e2a-9c6b-7d8e1f2a3b4c" />
   <Project Path="HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj" Id="9b1a636f-63cc-415d-b568-77217cb13573" />
   <Project Path="HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj" Id="4be0d3da-4d23-420a-b013-d8db47bf7604" />


### PR DESCRIPTION
Rename workflow and job to "Weekly Dependencies" and add explicit permissions in weekly-deps.yml. Remove custom <Build> configuration from AppConfiguration project in HoneyDrunk.Vault.slnx for consistency.