### PR TITLE
chore(ci): switch token for nightly-security and sync workflows

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -20,4 +20,4 @@ jobs:
       enable-secret-scan: true
       create-issues: true
     secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.slnx
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.slnx
@@ -26,8 +26,11 @@
     <File Path="../docs/Testing.md" />
   </Folder>
   <Folder Name="/Pipelines/">
+    <File Path="../.github/workflows/hive-field-mirror.yml" />
+    <File Path="../.github/workflows/nightly-security.yml" />
     <File Path="../.github/workflows/publish.yml" />
     <File Path="../.github/workflows/validate-pr.yml" />
+    <File Path="../.github/workflows/weekly-deps.yml" />
   </Folder>
   <Project Path="HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj" />
   <Project Path="HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj" />


### PR DESCRIPTION
replace GITHUB_TOKEN with HIVE_FIELD_MIRROR_TOKEN in nightly-security.yml add hive-field-mirror, nightly-security, and weekly-deps workflows to solution file