### PR TITLE
ci(pr): set explicit permissions for pr-core workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,11 @@ permissions:
 jobs:
   pr-core:
     name: PR Core
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write  # CodeQL SARIF upload
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
     with:
       dotnet-version: '10.0.x'


### PR DESCRIPTION
Explicitly grant contents:read, checks:write, pull-requests:write, and security-events:write to pr-core job in pr.yml to enable PR status updates, CodeQL SARIF uploads, and repository interactions