### PR TITLE
ci(pr): restrict workflow-level permissions to contents:read

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: write
 
 jobs:
   pr-core:


### PR DESCRIPTION
## Summary
- Tightens top-level ``permissions:`` in ``pr.yml`` to ``contents: read`` only.
- The ``pr-core`` job retains its full scoped permission set (``contents: read``, ``checks: write``, ``pull-requests: write``, ``security-events: write``) needed for CodeQL SARIF upload and PR/check reporting.

## Why
Least-privilege hygiene: future jobs added to ``pr.yml`` now start read-only and must explicitly opt in to writes, so new steps can't accidentally inherit ``checks: write`` / ``pull-requests: write``.

## Test plan
- [ ] Open a follow-up PR against this branch after merge and confirm the PR summary / check-run posting still works on the ``pr-core`` job.
- [ ] Confirm CodeQL SARIF upload still succeeds once the HoneyDrunk.Actions security-scan changes land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)