### PR TITLE
feat: add ADR-0026 tenant-scoped secret resolution

### DIFF
--- a/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0] - 2026-05-04
+
+### Added
+
+- Documented ADR-0026 tenant-scoped Vault naming in `docs/Tenancy.md`.
+- Added `TenantScopedSecretResolver` in `HoneyDrunk.Vault` for `tenant-{tenantId}-{secretName}` lookup with standard-path fallback for internal tenants and missing tenant secrets.
 ## [0.3.0] - 2026-04-11
 
 ### Added
@@ -52,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Health, telemetry, and lifecycle integration with HoneyDrunk.Kernel
 - Resilience options (retry and circuit breaker)
 
+[0.4.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.4.0
 [0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.2.0
 [0.1.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.1.0

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-04
+
+### Changed
+- Version alignment with the ADR-0026 Vault tenancy support release in the core package. No functional provider changes.
 ## [0.3.0] - 2026-04-12
 
 ### Added

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
@@ -9,10 +9,10 @@
     <NoWarn>$(NoWarn);CA1873;CA1016</NoWarn>
 
     <PackageId>HoneyDrunk.Vault.EventGrid</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Event Grid webhook helpers for HoneyDrunk.Vault cache invalidation.</Description>
-    <PackageReleaseNotes>v0.3.0: Added Event Grid cache invalidation webhook support for ADR-0006 Tier 3 rotation propagation.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;eventgrid;azure;webhook;secrets;cache;rotation</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-04
+
+### Changed
+- Version alignment with the ADR-0026 Vault tenancy support release in the core package. No functional provider changes.
 ## [0.3.0] - 2026-04-11
 
 ### Added

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -9,10 +9,10 @@
     <NoWarn>$(NoWarn);CA1873;CA1016</NoWarn>
 
     <PackageId>HoneyDrunk.Vault.Providers.AppConfiguration</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure App Configuration bootstrap extensions for HoneyDrunk.Vault using environment variable discovery.</Description>
-    <PackageReleaseNotes>v0.3.0: Initial release with env-var-driven bootstrap for Azure App Configuration.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;app-configuration;azure;feature-flags;configuration;bootstrap</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-04
+
+### Changed
+- Version alignment with the ADR-0026 Vault tenancy support release in the core package. No functional provider changes.
 ## [0.3.0] - 2026-04-11
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Aws</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>AWS Secrets Manager provider for HoneyDrunk.Vault. Provides secure secret management using AWS Secrets Manager with support for IAM roles, access keys, and EC2 instance profiles.</Description>
-    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with core library version. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;aws;secrets-manager;iam;access-keys;instance-profile;ec2;authentication</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-04
+
+### Changed
+- Version alignment with the ADR-0026 Vault tenancy support release in the core package. No functional provider changes.
 ## [0.3.0] - 2026-04-11
 
 ### Added

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.AzureKeyVault</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Key Vault provider for HoneyDrunk.Vault. Provides enterprise-grade secret management using Azure Key Vault with support for Managed Identity and Service Principal authentication.</Description>
-    <PackageReleaseNotes>v0.3.0: Added environment-variable bootstrap API updates and naming fixes. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;azure;key-vault;managed-identity;service-principal;authentication;enterprise</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-04
+
+### Changed
+- Version alignment with the ADR-0026 Vault tenancy support release in the core package. No functional provider changes.
 ## [0.3.0] - 2026-04-11
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Configuration</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>.NET Configuration provider for HoneyDrunk.Vault. Enables reading secrets and configuration from standard .NET configuration sources (appsettings.json, environment variables, user secrets).</Description>
-    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with the core library version and provider packaging metadata.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;configuration;secrets;appsettings;environment-variables;user-secrets;dotnet-config</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-04
+
+### Changed
+- Version alignment with the ADR-0026 Vault tenancy support release in the core package. No functional provider changes.
 ## [0.3.0] - 2026-04-11
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.File</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>File-based secrets and configuration provider for HoneyDrunk.Vault. Ideal for local development and testing with support for file watching and optional encryption.</Description>
-    <PackageReleaseNotes>v0.3.0: Maintenance release aligned with the core library version. No functional provider changes in this release.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;configuration;file;development;testing;file-watcher</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-04
+
+### Changed
+- Version alignment with the ADR-0026 Vault tenancy support release in the core package. No functional provider changes.
 ## [0.3.0] - 2026-04-11
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.InMemory</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory provider for HoneyDrunk.Vault. Ideal for unit testing and integration testing with fast, thread-safe secret and configuration storage.</Description>
-    <PackageReleaseNotes>v0.3.0: Package metadata and release documentation alignment update. See CHANGELOG.md for version-specific details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;testing;unit-testing;in-memory;mock;development</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.5.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/TenantScopedSecretResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/TenantScopedSecretResolverTests.cs
@@ -1,0 +1,105 @@
+using HoneyDrunk.Kernel.Abstractions.Identity;
+using HoneyDrunk.Vault.Providers.InMemory.Services;
+using HoneyDrunk.Vault.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Collections.Concurrent;
+
+namespace HoneyDrunk.Vault.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="TenantScopedSecretResolver"/>.
+/// </summary>
+public sealed class TenantScopedSecretResolverTests
+{
+    private readonly ConcurrentDictionary<string, string> _secrets = new(StringComparer.OrdinalIgnoreCase);
+    private readonly TenantScopedSecretResolver _resolver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TenantScopedSecretResolverTests"/> class.
+    /// </summary>
+    public TenantScopedSecretResolverTests()
+    {
+        var store = new InMemorySecretStore(_secrets, NullLogger<InMemorySecretStore>.Instance);
+        _resolver = new TenantScopedSecretResolver(store);
+    }
+
+    /// <summary>
+    /// Verifies tenant-scoped secrets are resolved before shared secrets.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ResolveAsync_ReturnsTenantScopedSecret_WhenPresent()
+    {
+        // Arrange
+        var tenantId = TenantId.NewId();
+        const string secretName = "resend-api-key";
+        var tenantScopedName = TenantScopedSecretResolver.FormatTenantScopedName(tenantId, secretName);
+        _secrets[secretName] = "shared-value";
+        _secrets[tenantScopedName] = "tenant-value";
+
+        // Act
+        var result = await _resolver.ResolveAsync(tenantId, secretName);
+
+        // Assert
+        Assert.Equal(tenantScopedName, result.Identifier.Name);
+        Assert.Equal("tenant-value", result.Value);
+    }
+
+    /// <summary>
+    /// Verifies tenant-scoped resolution falls back to the shared node path when tenant secret is absent.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ResolveAsync_FallsBackToSharedSecret_WhenTenantScopedSecretMissing()
+    {
+        // Arrange
+        var tenantId = TenantId.NewId();
+        const string secretName = "resend-api-key";
+        _secrets[secretName] = "shared-value";
+
+        // Act
+        var result = await _resolver.ResolveAsync(tenantId, secretName);
+
+        // Assert
+        Assert.Equal(secretName, result.Identifier.Name);
+        Assert.Equal("shared-value", result.Value);
+    }
+
+    /// <summary>
+    /// Verifies internal tenant resolution short-circuits to the shared node path.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ResolveAsync_UsesSharedSecret_WhenTenantIsInternal()
+    {
+        // Arrange
+        var tenantId = new TenantId("00000000000000000000000000");
+        const string secretName = "resend-api-key";
+        _secrets[secretName] = "shared-value";
+        _secrets[TenantScopedSecretResolver.FormatTenantScopedName(tenantId, secretName)] = "tenant-value";
+
+        // Act
+        var result = await _resolver.ResolveAsync(tenantId, secretName);
+
+        // Assert
+        Assert.Equal(secretName, result.Identifier.Name);
+        Assert.Equal("shared-value", result.Value);
+    }
+
+    /// <summary>
+    /// Verifies TryResolveAsync returns failure when neither tenant-scoped nor shared secret exists.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task TryResolveAsync_ReturnsFailure_WhenNoSecretExists()
+    {
+        // Arrange
+        var tenantId = TenantId.NewId();
+
+        // Act
+        var result = await _resolver.TryResolveAsync(tenantId, "missing-secret");
+
+        // Assert
+        Assert.False(result.IsSuccess);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/TenantScopedSecretResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/TenantScopedSecretResolverTests.cs
@@ -1,7 +1,11 @@
 using HoneyDrunk.Kernel.Abstractions.Identity;
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Exceptions;
+using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Providers.InMemory.Services;
 using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using System.Collections.Concurrent;
 
 namespace HoneyDrunk.Vault.Tests.Services;
@@ -101,5 +105,82 @@ public sealed class TenantScopedSecretResolverTests
 
         // Assert
         Assert.False(result.IsSuccess);
+    }
+
+    /// <summary>
+    /// Verifies tenant-scoped provider failures are not masked by shared-secret fallback.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ResolveAsync_PropagatesTenantScopedProviderFailure()
+    {
+        // Arrange
+        var tenantId = TenantId.NewId();
+        var store = new Mock<ISecretStore>();
+        store.Setup(s => s.GetSecretAsync(
+                It.Is<SecretIdentifier>(id => id.Name.StartsWith("tenant-", StringComparison.Ordinal)),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("provider offline"));
+
+        var resolver = new TenantScopedSecretResolver(store.Object);
+
+        // Act + Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() => resolver.ResolveAsync(tenantId, "resend-api-key"));
+        store.Verify(s => s.GetSecretAsync(It.Is<SecretIdentifier>(id => id.Name == "resend-api-key"), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies tenant-scoped not-found failures still fall back to the shared secret.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task ResolveAsync_FallsBackOnlyWhenTenantScopedSecretNotFound()
+    {
+        // Arrange
+        var tenantId = TenantId.NewId();
+        var shared = new SecretValue(new SecretIdentifier("resend-api-key"), "shared-value", "v1");
+        var store = new Mock<ISecretStore>();
+        store.Setup(s => s.GetSecretAsync(
+                It.Is<SecretIdentifier>(id => id.Name.StartsWith("tenant-", StringComparison.Ordinal)),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SecretNotFoundException("tenant-secret"));
+        store.Setup(s => s.GetSecretAsync(
+                It.Is<SecretIdentifier>(id => id.Name == "resend-api-key"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(shared);
+
+        var resolver = new TenantScopedSecretResolver(store.Object);
+
+        // Act
+        var result = await resolver.ResolveAsync(tenantId, "resend-api-key");
+
+        // Assert
+        Assert.Equal(shared, result);
+    }
+
+    /// <summary>
+    /// Verifies TryResolveAsync returns tenant-scoped provider errors instead of falling back to shared secrets.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    [Fact]
+    public async Task TryResolveAsync_ReturnsFailure_WhenTenantScopedProviderFails()
+    {
+        // Arrange
+        var tenantId = TenantId.NewId();
+        var store = new Mock<ISecretStore>();
+        store.Setup(s => s.GetSecretAsync(
+                It.Is<SecretIdentifier>(id => id.Name.StartsWith("tenant-", StringComparison.Ordinal)),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("provider offline"));
+
+        var resolver = new TenantScopedSecretResolver(store.Object);
+
+        // Act
+        var result = await resolver.TryResolveAsync(tenantId, "resend-api-key");
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Contains("provider offline", result.ErrorMessage, StringComparison.Ordinal);
+        store.Verify(s => s.TryGetSecretAsync(It.Is<SecretIdentifier>(id => id.Name == "resend-api-key"), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-04
+
+### Added
+- Added `TenantScopedSecretResolver` for ADR-0026 tenant-aware secret lookup using `tenant-{tenantId}-{secretName}` with shared-path fallback.
+- Added tenancy documentation covering the per-tenant secret scoping pattern and internal-tenant behavior.
 ## [0.3.0] - 2026-04-11
 
 ### Added

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Secrets and configuration management library for .NET. Provides a unified abstraction for accessing secrets from multiple providers (File, Azure Key Vault, AWS Secrets Manager, Configuration, In-Memory). Integrated with HoneyDrunk.Kernel for lifecycle management, health reporting, and distributed telemetry.</Description>
-    <PackageReleaseNotes>v0.3.0: Added bootstrap-related provider integration updates and changelog cleanup. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.4.0: Added ADR-0026 tenant-scoped secret resolver and tenancy documentation. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;secrets;configuration;provider;cache;resilience;circuit-breaker;retry;azure-keyvault;aws;kernel;grid;distributed-tracing</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -27,8 +27,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.4.0" />
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/TenantScopedSecretResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/TenantScopedSecretResolver.cs
@@ -1,5 +1,6 @@
 using HoneyDrunk.Kernel.Abstractions.Identity;
 using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
 
 namespace HoneyDrunk.Vault.Services;
@@ -57,13 +58,16 @@ public sealed class TenantScopedSecretResolver
             return await _secretStore.GetSecretAsync(new SecretIdentifier(secretName), cancellationToken).ConfigureAwait(false);
         }
 
-        var tenantScoped = await _secretStore.TryGetSecretAsync(
-            new SecretIdentifier(FormatTenantScopedName(tenantId, secretName)),
-            cancellationToken).ConfigureAwait(false);
-
-        return tenantScoped.IsSuccess
-            ? tenantScoped.Value!
-            : await _secretStore.GetSecretAsync(new SecretIdentifier(secretName), cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await _secretStore.GetSecretAsync(
+                new SecretIdentifier(FormatTenantScopedName(tenantId, secretName)),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (SecretNotFoundException)
+        {
+            return await _secretStore.GetSecretAsync(new SecretIdentifier(secretName), cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <summary>
@@ -85,12 +89,21 @@ public sealed class TenantScopedSecretResolver
             return await _secretStore.TryGetSecretAsync(new SecretIdentifier(secretName), cancellationToken).ConfigureAwait(false);
         }
 
-        var tenantScoped = await _secretStore.TryGetSecretAsync(
-            new SecretIdentifier(FormatTenantScopedName(tenantId, secretName)),
-            cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var tenantScoped = await _secretStore.GetSecretAsync(
+                new SecretIdentifier(FormatTenantScopedName(tenantId, secretName)),
+                cancellationToken).ConfigureAwait(false);
 
-        return tenantScoped.IsSuccess
-            ? tenantScoped
-            : await _secretStore.TryGetSecretAsync(new SecretIdentifier(secretName), cancellationToken).ConfigureAwait(false);
+            return VaultResult.Success(tenantScoped);
+        }
+        catch (SecretNotFoundException)
+        {
+            return await _secretStore.TryGetSecretAsync(new SecretIdentifier(secretName), cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return VaultResult.Failure<SecretValue>($"Failed to retrieve tenant-scoped secret '{secretName}': {ex.Message}");
+        }
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/TenantScopedSecretResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/TenantScopedSecretResolver.cs
@@ -1,0 +1,96 @@
+using HoneyDrunk.Kernel.Abstractions.Identity;
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Models;
+
+namespace HoneyDrunk.Vault.Services;
+
+/// <summary>
+/// Resolves secrets using the ADR-0026 tenant-scoped naming convention.
+/// </summary>
+/// <remarks>
+/// Tenant-scoped secrets are looked up as <c>tenant-{tenantId}-{secretName}</c> first.
+/// Internal tenants and tenant misses fall back to the standard node-level secret name.
+/// </remarks>
+public sealed class TenantScopedSecretResolver
+{
+    private const string TenantSecretPrefix = "tenant-";
+    private readonly ISecretStore _secretStore;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TenantScopedSecretResolver"/> class.
+    /// </summary>
+    /// <param name="secretStore">The secret store to resolve from.</param>
+    public TenantScopedSecretResolver(ISecretStore secretStore)
+    {
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+    }
+
+    /// <summary>
+    /// Formats the ADR-0026 tenant-scoped secret name for a node-level secret name.
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="secretName">The node-level secret name.</param>
+    /// <returns>The tenant-scoped secret name.</returns>
+    public static string FormatTenantScopedName(TenantId tenantId, string secretName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(secretName);
+
+        return $"{TenantSecretPrefix}{tenantId}-{secretName}";
+    }
+
+    /// <summary>
+    /// Resolves a secret for the supplied tenant, falling back to the standard node-level secret when appropriate.
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="secretName">The node-level secret name.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The resolved secret value.</returns>
+    public async Task<SecretValue> ResolveAsync(
+        TenantId tenantId,
+        string secretName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(secretName);
+
+        if (tenantId.IsInternal)
+        {
+            return await _secretStore.GetSecretAsync(new SecretIdentifier(secretName), cancellationToken).ConfigureAwait(false);
+        }
+
+        var tenantScoped = await _secretStore.TryGetSecretAsync(
+            new SecretIdentifier(FormatTenantScopedName(tenantId, secretName)),
+            cancellationToken).ConfigureAwait(false);
+
+        return tenantScoped.IsSuccess
+            ? tenantScoped.Value!
+            : await _secretStore.GetSecretAsync(new SecretIdentifier(secretName), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Attempts to resolve a secret for the supplied tenant, falling back to the standard node-level secret when appropriate.
+    /// </summary>
+    /// <param name="tenantId">The tenant identifier.</param>
+    /// <param name="secretName">The node-level secret name.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the resolved secret value if found.</returns>
+    public async Task<VaultResult<SecretValue>> TryResolveAsync(
+        TenantId tenantId,
+        string secretName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(secretName);
+
+        if (tenantId.IsInternal)
+        {
+            return await _secretStore.TryGetSecretAsync(new SecretIdentifier(secretName), cancellationToken).ConfigureAwait(false);
+        }
+
+        var tenantScoped = await _secretStore.TryGetSecretAsync(
+            new SecretIdentifier(FormatTenantScopedName(tenantId, secretName)),
+            cancellationToken).ConfigureAwait(false);
+
+        return tenantScoped.IsSuccess
+            ? tenantScoped
+            : await _secretStore.TryGetSecretAsync(new SecretIdentifier(secretName), cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/docs/Tenancy.md
+++ b/docs/Tenancy.md
@@ -1,0 +1,36 @@
+# Tenancy
+
+ADR-0026 defines tenant-scoped Vault lookup as a naming convention plus a thin resolver, not an `ISecretStore` contract change.
+
+## Secret naming
+
+Tenant-owned secrets use this pattern inside the node's standard vault:
+
+```text
+tenant-{tenantId}-{secretName}
+```
+
+Examples:
+
+- `tenant-01H2X3Y4Z5ABCDEABCDEABCDE-resend-api-key`
+- `tenant-01H2X3Y4Z5ABCDEABCDEABCDE-twilio-auth-token`
+- `resend-api-key` — the node-standard shared path, with no tenant prefix
+
+`tenantId` is the canonical ULID string form of `HoneyDrunk.Kernel.Abstractions.Identity.TenantId`.
+
+## Resolution behavior
+
+Use `TenantScopedSecretResolver` from `HoneyDrunk.Vault.Services` when a node supports tenant-specific secrets:
+
+1. If `tenantId.IsInternal` is true, resolve `secretName` directly from the node-standard path.
+2. Otherwise, try `tenant-{tenantId}-{secretName}` first.
+3. If the tenant-scoped secret is absent, fall back to `secretName`.
+
+This keeps internal Grid callers on the existing secret path and lets Free/Starter tenants share node-managed provider keys unless they bring their own tenant-scoped secret.
+
+```csharp
+var resolver = new TenantScopedSecretResolver(secretStore);
+var resendKey = await resolver.ResolveAsync(tenantId, "resend-api-key", cancellationToken);
+```
+
+Do not add tenant overloads to `ISecretStore`; tenancy is an opt-in usage pattern layered on top of the existing secret-store abstraction.

--- a/docs/Tenancy.md
+++ b/docs/Tenancy.md
@@ -12,8 +12,8 @@ tenant-{tenantId}-{secretName}
 
 Examples:
 
-- `tenant-01H2X3Y4Z5ABCDEABCDEABCDE-resend-api-key`
-- `tenant-01H2X3Y4Z5ABCDEABCDEABCDE-twilio-auth-token`
+- `tenant-01H2X3Y4Z5ABCDEABCDEABCDEF-resend-api-key`
+- `tenant-01H2X3Y4Z5ABCDEABCDEABCDEF-twilio-auth-token`
 - `resend-api-key` — the node-standard shared path, with no tenant prefix
 
 `tenantId` is the canonical ULID string form of `HoneyDrunk.Kernel.Abstractions.Identity.TenantId`.


### PR DESCRIPTION
## Summary
- add `TenantScopedSecretResolver` layered over `ISecretStore` for ADR-0026 tenant-scoped secret lookup
- document the `tenant-{tenantId}-{secretName}` convention in `docs/Tenancy.md`
- bump Vault packages to `0.4.0`, update changelogs, and move Kernel dependencies to `0.5.0`

## Scope
Closes #27
ADR: https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0026-grid-multi-tenant-primitives.md

## Validation
- `dotnet restore HoneyDrunk.Vault.slnx --ignore-failed-sources` (private Azure Artifacts vulnerability feed returned NU1900 warnings)
- `dotnet test HoneyDrunk.Vault.slnx --no-restore` — passed 187/187 (NU1900 warnings only)
