### PR TITLE
chore: align Vault with Kernel 0.7.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,7 @@ jobs:
             HoneyDrunk.Vault.Providers.Configuration
             HoneyDrunk.Vault.Providers.InMemory
             HoneyDrunk.Vault.Providers.AppConfiguration
+            HoneyDrunk.Vault.EventGrid
           docs-url: 'https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault#readme'
 
       - name: Create GitHub Release

--- a/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/CHANGELOG.md
@@ -13,8 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [HoneyDrunk.Vault.Providers.File CHANGELOG](HoneyDrunk.Vault.Providers.File/CHANGELOG.md)
 - [HoneyDrunk.Vault.Providers.InMemory CHANGELOG](HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md)
 - [HoneyDrunk.Vault.Providers.AppConfiguration CHANGELOG](HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md)
+- [HoneyDrunk.Vault.EventGrid CHANGELOG](HoneyDrunk.Vault.EventGrid/CHANGELOG.md)
 
 ---
+
+## [0.5.0] - 2026-05-18
+
+### Changed
+- Aligned Vault package versions and Kernel references with `HoneyDrunk.Kernel`/`HoneyDrunk.Kernel.Abstractions` v0.7.0.
+- Centralized provider bootstrap configuration resolution, secret-store facade wrappers, and config-source value conversion/orchestration to reduce duplicate provider helper logic.
 
 ## [0.4.0] - 2026-05-04
 
@@ -58,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Health, telemetry, and lifecycle integration with HoneyDrunk.Kernel
 - Resilience options (retry and circuit breaker)
 
+[0.5.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.5.0
 [0.4.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.4.0
 [0.3.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.3.0
 [0.2.0]: https://github.com/HoneyDrunkStudios/HoneyDrunk.Vault/releases/tag/v0.2.0

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+- Version alignment with the Vault Kernel v0.7.0 adoption and provider-helper consolidation release. No functional EventGrid changes.
+
 ## [0.4.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
@@ -9,10 +9,10 @@
     <NoWarn>$(NoWarn);CA1873;CA1016</NoWarn>
 
     <PackageId>HoneyDrunk.Vault.EventGrid</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Event Grid webhook helpers for HoneyDrunk.Vault cache invalidation.</Description>
-    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Version alignment with the Vault Kernel v0.7.0 adoption and provider-helper consolidation release. No functional EventGrid changes. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;eventgrid;azure;webhook;secrets;cache;rotation</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+- Aligned Vault package versions and Kernel references with `HoneyDrunk.Kernel`/`HoneyDrunk.Kernel.Abstractions` v0.7.0.
+- Centralized provider bootstrap configuration resolution, secret-store facade wrappers, and config-source value conversion/orchestration to reduce duplicate provider helper logic.
+
 ## [0.4.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/BootstrapConfigurationResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/BootstrapConfigurationResolver.cs
@@ -1,10 +1,11 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using SharedBootstrapConfigurationResolver = HoneyDrunk.Vault.Configuration.BootstrapConfigurationResolver;
 
 namespace HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
 
 /// <summary>
-/// Resolves bootstrap configuration from the service collection or environment.
+/// Resolves App Configuration bootstrap settings.
 /// </summary>
 public static class BootstrapConfigurationResolver
 {
@@ -15,17 +16,7 @@ public static class BootstrapConfigurationResolver
     /// <returns>The resolved configuration instance.</returns>
     public static IConfiguration Resolve(IServiceCollection services)
     {
-        ArgumentNullException.ThrowIfNull(services);
-
-        var descriptor = services.LastOrDefault(static d => d.ServiceType == typeof(IConfiguration));
-        if (descriptor?.ImplementationInstance is IConfiguration configuration)
-        {
-            return configuration;
-        }
-
-        return new ConfigurationBuilder()
-            .AddEnvironmentVariables()
-            .Build();
+        return SharedBootstrapConfigurationResolver.Resolve(services);
     }
 
     /// <summary>
@@ -37,12 +28,7 @@ public static class BootstrapConfigurationResolver
     /// <returns><see langword="true"/> if the environment is Development; otherwise, <see langword="false"/>.</returns>
     public static bool IsDevelopment(IConfiguration configuration, string aspNetCoreEnvironmentSetting, string dotNetEnvironmentSetting)
     {
-        var environment = configuration[aspNetCoreEnvironmentSetting] ??
-            configuration[dotNetEnvironmentSetting] ??
-            Environment.GetEnvironmentVariable(aspNetCoreEnvironmentSetting) ??
-            Environment.GetEnvironmentVariable(dotNetEnvironmentSetting);
-
-        return string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase);
+        return SharedBootstrapConfigurationResolver.IsDevelopment(configuration, aspNetCoreEnvironmentSetting, dotNetEnvironmentSetting);
     }
 
     /// <summary>
@@ -54,14 +40,6 @@ public static class BootstrapConfigurationResolver
     /// <returns><see langword="true"/> if a valid URI was found; otherwise, <see langword="false"/>.</returns>
     public static bool TryGetEndpoint(IConfiguration configuration, string settingName, out Uri? endpoint)
     {
-        var value = configuration[settingName];
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            value = Environment.GetEnvironmentVariable(settingName);
-        }
-
-        var isValid = Uri.TryCreate(value, UriKind.Absolute, out var parsed);
-        endpoint = parsed;
-        return isValid;
+        return SharedBootstrapConfigurationResolver.TryGetUri(configuration, settingName, out endpoint);
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -9,10 +9,10 @@
     <NoWarn>$(NoWarn);CA1873;CA1016</NoWarn>
 
     <PackageId>HoneyDrunk.Vault.Providers.AppConfiguration</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure App Configuration bootstrap extensions for HoneyDrunk.Vault using environment variable discovery.</Description>
-    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Align Kernel references to v0.7.0 and consolidate Vault provider bootstrap, secret-store facade, and config-source helpers. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;app-configuration;azure;feature-flags;configuration;bootstrap</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -32,7 +32,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.5.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
   </ItemGroup>
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+- Aligned Vault package versions and Kernel references with `HoneyDrunk.Kernel`/`HoneyDrunk.Kernel.Abstractions` v0.7.0.
+- Centralized provider bootstrap configuration resolution, secret-store facade wrappers, and config-source value conversion/orchestration to reduce duplicate provider helper logic.
+
 ## [0.4.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Aws</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>AWS Secrets Manager provider for HoneyDrunk.Vault. Provides secure secret management using AWS Secrets Manager with support for IAM roles, access keys, and EC2 instance profiles.</Description>
-    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Align Kernel references to v0.7.0 and consolidate Vault provider bootstrap, secret-store facade, and config-source helpers. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;aws;secrets-manager;iam;access-keys;instance-profile;ec2;authentication</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/Services/AwsSecretsManagerSecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/Services/AwsSecretsManagerSecretStore.cs
@@ -5,6 +5,7 @@ using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Providers.Aws.Configuration;
+using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -112,19 +113,7 @@ public sealed class AwsSecretsManagerSecretStore : ISecretStore, ISecretProvider
     {
         ArgumentNullException.ThrowIfNull(identifier);
 
-        try
-        {
-            var result = await GetSecretAsync(identifier, cancellationToken).ConfigureAwait(false);
-            return VaultResult.Success(result);
-        }
-        catch (SecretNotFoundException)
-        {
-            return VaultResult.Failure<SecretValue>($"Secret '{identifier.Name}' not found");
-        }
-        catch (VaultOperationException ex)
-        {
-            return VaultResult.Failure<SecretValue>(ex.Message);
-        }
+        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, _logger, "AWS Secrets Manager", cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -185,19 +174,19 @@ public sealed class AwsSecretsManagerSecretStore : ISecretStore, ISecretProvider
     /// <inheritdoc/>
     public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
     {
-        return GetSecretAsync(new SecretIdentifier(key, version), cancellationToken);
+        return SecretStoreFacade.FetchSecretAsync(GetSecretAsync, key, version, cancellationToken);
     }
 
     /// <inheritdoc/>
     public async Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
     {
-        return await TryGetSecretAsync(new SecretIdentifier(key, version), cancellationToken).ConfigureAwait(false);
+        return await SecretStoreFacade.TryFetchSecretAsync(TryGetSecretAsync, key, version, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
     {
-        return ListSecretVersionsAsync(key, cancellationToken);
+        return SecretStoreFacade.ListVersionsAsync(ListSecretVersionsAsync, key, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+- Aligned Vault package versions and Kernel references with `HoneyDrunk.Kernel`/`HoneyDrunk.Kernel.Abstractions` v0.7.0.
+- Centralized provider bootstrap configuration resolution, secret-store facade wrappers, and config-source value conversion/orchestration to reduce duplicate provider helper logic.
+
 ## [0.4.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/BootstrapConfigurationResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Extensions/BootstrapConfigurationResolver.cs
@@ -1,11 +1,12 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics.CodeAnalysis;
+using SharedBootstrapConfigurationResolver = HoneyDrunk.Vault.Configuration.BootstrapConfigurationResolver;
 
 namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
 
 /// <summary>
-/// Resolves bootstrap configuration from the service collection or environment.
+/// Resolves Azure Key Vault bootstrap settings.
 /// </summary>
 public static class BootstrapConfigurationResolver
 {
@@ -16,17 +17,7 @@ public static class BootstrapConfigurationResolver
     /// <returns>The resolved configuration instance.</returns>
     public static IConfiguration Resolve(IServiceCollection services)
     {
-        ArgumentNullException.ThrowIfNull(services);
-
-        var descriptor = services.LastOrDefault(static d => d.ServiceType == typeof(IConfiguration));
-        if (descriptor?.ImplementationInstance is IConfiguration configuration)
-        {
-            return configuration;
-        }
-
-        return new ConfigurationBuilder()
-            .AddEnvironmentVariables()
-            .Build();
+        return SharedBootstrapConfigurationResolver.Resolve(services);
     }
 
     /// <summary>
@@ -38,12 +29,7 @@ public static class BootstrapConfigurationResolver
     /// <returns><see langword="true"/> if the environment is Development; otherwise, <see langword="false"/>.</returns>
     public static bool IsDevelopment(IConfiguration configuration, string aspNetCoreEnvironmentSetting, string dotNetEnvironmentSetting)
     {
-        var environment = configuration[aspNetCoreEnvironmentSetting] ??
-            configuration[dotNetEnvironmentSetting] ??
-            Environment.GetEnvironmentVariable(aspNetCoreEnvironmentSetting) ??
-            Environment.GetEnvironmentVariable(dotNetEnvironmentSetting);
-
-        return string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase);
+        return SharedBootstrapConfigurationResolver.IsDevelopment(configuration, aspNetCoreEnvironmentSetting, dotNetEnvironmentSetting);
     }
 
     /// <summary>
@@ -55,14 +41,6 @@ public static class BootstrapConfigurationResolver
     /// <returns><see langword="true"/> if a valid URI was found; otherwise, <see langword="false"/>.</returns>
     public static bool TryGetKeyVaultUri(IConfiguration configuration, string settingName, [NotNullWhen(true)] out Uri? vaultUri)
     {
-        var value = configuration[settingName];
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            value = Environment.GetEnvironmentVariable(settingName);
-        }
-
-        var isValid = Uri.TryCreate(value, UriKind.Absolute, out var uri);
-        vaultUri = uri;
-        return isValid;
+        return SharedBootstrapConfigurationResolver.TryGetUri(configuration, settingName, out vaultUri);
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.AzureKeyVault</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Key Vault provider for HoneyDrunk.Vault. Provides enterprise-grade secret management using Azure Key Vault with support for Managed Identity and Service Principal authentication.</Description>
-    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Align Kernel references to v0.7.0 and consolidate Vault provider bootstrap, secret-store facade, and config-source helpers. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;azure;key-vault;managed-identity;service-principal;authentication;enterprise</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Services/AzureKeyVaultConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Services/AzureKeyVaultConfigSource.cs
@@ -71,7 +71,7 @@ public sealed class AzureKeyVaultConfigSource(
     /// <inheritdoc/>
     public async Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
     {
-        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken).ConfigureAwait(false);
+        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken, _logger).ConfigureAwait(false);
     }
 
     private static string NormalizeKeyForKeyVault(string key)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Services/AzureKeyVaultConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Services/AzureKeyVaultConfigSource.cs
@@ -1,6 +1,7 @@
 using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
 
 namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Services;
@@ -24,10 +25,7 @@ public sealed class AzureKeyVaultConfigSource(
     /// <inheritdoc/>
     public async Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         _logger.LogDebug("Getting configuration value for key '{Key}' from Azure Key Vault", key);
 
@@ -47,10 +45,7 @@ public sealed class AzureKeyVaultConfigSource(
     /// <inheritdoc/>
     public async Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         _logger.LogDebug("Attempting to get configuration value for key '{Key}' from Azure Key Vault", key);
 
@@ -70,58 +65,13 @@ public sealed class AzureKeyVaultConfigSource(
     /// <inheritdoc/>
     public async Task<T> GetConfigValueAsync<T>(string key, CancellationToken cancellationToken = default)
     {
-        var value = await GetConfigValueAsync(key, cancellationToken).ConfigureAwait(false);
-        return ConvertValue<T>(value, key);
+        return await ConfigSourceFacade.GetValueAsync<T>(GetConfigValueAsync, key, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var value = await TryGetConfigValueAsync(key, cancellationToken).ConfigureAwait(false);
-
-            if (value == null)
-            {
-                return defaultValue;
-            }
-
-            return ConvertValue<T>(value, key);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Error converting configuration key '{Key}', returning default value", key);
-            return defaultValue;
-        }
-    }
-
-    private static T ConvertValue<T>(string value, string key)
-    {
-        try
-        {
-            var targetType = typeof(T);
-
-            if (targetType == typeof(string))
-            {
-                return (T)(object)value;
-            }
-
-            var converter = System.ComponentModel.TypeDescriptor.GetConverter(targetType);
-            if (converter.CanConvertFrom(typeof(string)))
-            {
-                var result = converter.ConvertFromInvariantString(value);
-                if (result != null)
-                {
-                    return (T)result;
-                }
-            }
-
-            throw new InvalidOperationException($"Cannot convert value to type {targetType.Name}");
-        }
-        catch (Exception ex)
-        {
-            throw new VaultOperationException($"Failed to convert configuration value for key '{key}' to type {typeof(T).Name}", ex);
-        }
+        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken).ConfigureAwait(false);
     }
 
     private static string NormalizeKeyForKeyVault(string key)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Services/AzureKeyVaultSecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Services/AzureKeyVaultSecretStore.cs
@@ -3,6 +3,7 @@ using Azure.Security.KeyVault.Secrets;
 using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
 
 namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Services;
@@ -73,21 +74,7 @@ public sealed class AzureKeyVaultSecretStore(
 
         _logger.LogDebug("Attempting to get secret '{SecretName}' from Azure Key Vault", identifier.Name);
 
-        try
-        {
-            var secretValue = await GetSecretAsync(identifier, cancellationToken).ConfigureAwait(false);
-            return VaultResult.Success(secretValue);
-        }
-        catch (SecretNotFoundException ex)
-        {
-            _logger.LogDebug("Secret '{SecretName}' not found in Azure Key Vault", identifier.Name);
-            return VaultResult.Failure<SecretValue>($"Secret '{identifier.Name}' not found: {ex.Message}");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving secret '{SecretName}' from Azure Key Vault", identifier.Name);
-            return VaultResult.Failure<SecretValue>($"Failed to retrieve secret '{identifier.Name}': {ex.Message}");
-        }
+        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, _logger, "Azure Key Vault", cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -138,19 +125,19 @@ public sealed class AzureKeyVaultSecretStore(
     /// <inheritdoc/>
     public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
     {
-        return GetSecretAsync(new SecretIdentifier(key, version), cancellationToken);
+        return SecretStoreFacade.FetchSecretAsync(GetSecretAsync, key, version, cancellationToken);
     }
 
     /// <inheritdoc/>
     public async Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
     {
-        return await TryGetSecretAsync(new SecretIdentifier(key, version), cancellationToken).ConfigureAwait(false);
+        return await SecretStoreFacade.TryFetchSecretAsync(TryGetSecretAsync, key, version, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
     {
-        return ListSecretVersionsAsync(key, cancellationToken);
+        return SecretStoreFacade.ListVersionsAsync(ListSecretVersionsAsync, key, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+- Aligned Vault package versions and Kernel references with `HoneyDrunk.Kernel`/`HoneyDrunk.Kernel.Abstractions` v0.7.0.
+- Centralized provider bootstrap configuration resolution, secret-store facade wrappers, and config-source value conversion/orchestration to reduce duplicate provider helper logic.
+
 ## [0.4.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Configuration</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>.NET Configuration provider for HoneyDrunk.Vault. Enables reading secrets and configuration from standard .NET configuration sources (appsettings.json, environment variables, user secrets).</Description>
-    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Align Kernel references to v0.7.0 and consolidate Vault provider bootstrap, secret-store facade, and config-source helpers. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;configuration;secrets;appsettings;environment-variables;user-secrets;dotnet-config</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -27,12 +27,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/Services/ConfigurationConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/Services/ConfigurationConfigSource.cs
@@ -1,5 +1,6 @@
 using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
+using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -23,10 +24,7 @@ public sealed class ConfigurationConfigSource(
     /// <inheritdoc/>
     public Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         _logger.LogDebug("Getting configuration value for key '{Key}' from configuration", key);
 
@@ -46,10 +44,7 @@ public sealed class ConfigurationConfigSource(
     /// <inheritdoc/>
     public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         _logger.LogDebug("Attempting to get configuration value for key '{Key}' from configuration", key);
 
@@ -70,10 +65,7 @@ public sealed class ConfigurationConfigSource(
     /// <inheritdoc/>
     public Task<T> GetConfigValueAsync<T>(string key, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         _logger.LogDebug("Getting typed configuration value for key '{Key}' as type '{Type}' from configuration", key, typeof(T).Name);
 
@@ -101,10 +93,7 @@ public sealed class ConfigurationConfigSource(
     /// <inheritdoc/>
     public Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         _logger.LogDebug("Attempting to get typed configuration value for key '{Key}' as type '{Type}' from configuration", key, typeof(T).Name);
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/Services/ConfigurationSecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/Services/ConfigurationSecretStore.cs
@@ -1,6 +1,7 @@
 using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -50,21 +51,7 @@ public sealed class ConfigurationSecretStore(
 
         _logger.LogDebug("Attempting to get secret '{SecretName}' from configuration", identifier.Name);
 
-        try
-        {
-            var secretValue = await GetSecretAsync(identifier, cancellationToken).ConfigureAwait(false);
-            return VaultResult.Success(secretValue);
-        }
-        catch (SecretNotFoundException ex)
-        {
-            _logger.LogDebug("Secret '{SecretName}' not found in configuration", identifier.Name);
-            return VaultResult.Failure<SecretValue>($"Secret '{identifier.Name}' not found: {ex.Message}");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving secret '{SecretName}' from configuration", identifier.Name);
-            return VaultResult.Failure<SecretValue>($"Failed to retrieve secret '{identifier.Name}': {ex.Message}");
-        }
+        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, _logger, "configuration", cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+- Aligned Vault package versions and Kernel references with `HoneyDrunk.Kernel`/`HoneyDrunk.Kernel.Abstractions` v0.7.0.
+- Centralized provider bootstrap configuration resolution, secret-store facade wrappers, and config-source value conversion/orchestration to reduce duplicate provider helper logic.
+
 ## [0.4.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.File</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>File-based secrets and configuration provider for HoneyDrunk.Vault. Ideal for local development and testing with support for file watching and optional encryption.</Description>
-    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Align Kernel references to v0.7.0 and consolidate Vault provider bootstrap, secret-store facade, and config-source helpers. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;configuration;file;development;testing;file-watcher</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileConfigSource.cs
@@ -1,6 +1,7 @@
 using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Providers.File.Configuration;
+using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
@@ -58,10 +59,7 @@ public sealed class FileConfigSource : IConfigSource, IConfigProvider, IDisposab
     /// <inheritdoc/>
     public Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         _logger.LogDebug("Getting configuration value for key '{Key}' from file store", key);
 
@@ -78,10 +76,7 @@ public sealed class FileConfigSource : IConfigSource, IConfigProvider, IDisposab
     /// <inheritdoc/>
     public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         _configValues.TryGetValue(key, out var value);
         return Task.FromResult(value);
@@ -90,27 +85,13 @@ public sealed class FileConfigSource : IConfigSource, IConfigProvider, IDisposab
     /// <inheritdoc/>
     public async Task<T> GetConfigValueAsync<T>(string key, CancellationToken cancellationToken = default)
     {
-        var value = await GetConfigValueAsync(key, cancellationToken).ConfigureAwait(false);
-        return ConvertValue<T>(value, key);
+        return await ConfigSourceFacade.GetValueAsync<T>(GetConfigValueAsync, key, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
     {
-        var value = await TryGetConfigValueAsync(key, cancellationToken).ConfigureAwait(false);
-        if (value == null)
-        {
-            return defaultValue;
-        }
-
-        try
-        {
-            return ConvertValue<T>(value, key);
-        }
-        catch
-        {
-            return defaultValue;
-        }
+        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken).ConfigureAwait(false);
     }
 
     // IConfigProvider implementation
@@ -152,47 +133,6 @@ public sealed class FileConfigSource : IConfigSource, IConfigProvider, IDisposab
         _watcher?.Dispose();
         _lock.Dispose();
         _disposed = true;
-    }
-
-    private static T ConvertValue<T>(string value, string key)
-    {
-        var targetType = typeof(T);
-
-        if (targetType == typeof(string))
-        {
-            return (T)(object)value;
-        }
-
-        try
-        {
-            if (targetType == typeof(int) || targetType == typeof(int?))
-            {
-                return (T)(object)int.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-
-            if (targetType == typeof(bool) || targetType == typeof(bool?))
-            {
-                return (T)(object)bool.Parse(value);
-            }
-
-            if (targetType == typeof(double) || targetType == typeof(double?))
-            {
-                return (T)(object)double.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-
-            if (targetType == typeof(long) || targetType == typeof(long?))
-            {
-                return (T)(object)long.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-
-            // Try JSON deserialization for complex types
-            return JsonSerializer.Deserialize<T>(value)
-                ?? throw new InvalidOperationException($"Failed to deserialize configuration value for key '{key}'");
-        }
-        catch (Exception ex)
-        {
-            throw new VaultOperationException($"Failed to convert configuration value for key '{key}' to type '{typeof(T).Name}'", ex);
-        }
     }
 
     private async Task LoadConfigAsync()

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileConfigSource.cs
@@ -91,7 +91,7 @@ public sealed class FileConfigSource : IConfigSource, IConfigProvider, IDisposab
     /// <inheritdoc/>
     public async Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
     {
-        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken).ConfigureAwait(false);
+        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken, _logger).ConfigureAwait(false);
     }
 
     // IConfigProvider implementation

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileSecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileSecretStore.cs
@@ -2,6 +2,7 @@ using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Providers.File.Configuration;
+using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
@@ -84,15 +85,7 @@ public sealed class FileSecretStore : ISecretStore, ISecretProvider, IDisposable
     {
         ArgumentNullException.ThrowIfNull(identifier);
 
-        try
-        {
-            var result = await GetSecretAsync(identifier, cancellationToken).ConfigureAwait(false);
-            return VaultResult.Success(result);
-        }
-        catch (SecretNotFoundException)
-        {
-            return VaultResult.Failure<SecretValue>($"Secret '{identifier.Name}' not found");
-        }
+        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, _logger, "file store", cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -120,19 +113,19 @@ public sealed class FileSecretStore : ISecretStore, ISecretProvider, IDisposable
     /// <inheritdoc/>
     public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
     {
-        return GetSecretAsync(new SecretIdentifier(key, version), cancellationToken);
+        return SecretStoreFacade.FetchSecretAsync(GetSecretAsync, key, version, cancellationToken);
     }
 
     /// <inheritdoc/>
     public async Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
     {
-        return await TryGetSecretAsync(new SecretIdentifier(key, version), cancellationToken).ConfigureAwait(false);
+        return await SecretStoreFacade.TryFetchSecretAsync(TryGetSecretAsync, key, version, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
     {
-        return ListSecretVersionsAsync(key, cancellationToken);
+        return SecretStoreFacade.ListVersionsAsync(ListSecretVersionsAsync, key, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+- Aligned Vault package versions and Kernel references with `HoneyDrunk.Kernel`/`HoneyDrunk.Kernel.Abstractions` v0.7.0.
+- Centralized provider bootstrap configuration resolution, secret-store facade wrappers, and config-source value conversion/orchestration to reduce duplicate provider helper logic.
+
 ## [0.4.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.InMemory</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory provider for HoneyDrunk.Vault. Ideal for unit testing and integration testing with fast, thread-safe secret and configuration storage.</Description>
-    <PackageReleaseNotes>v0.4.0: Version alignment with ADR-0026 Vault tenancy support in the core package. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.5.0: Align Kernel references to v0.7.0 and consolidate Vault provider bootstrap, secret-store facade, and config-source helpers. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;testing;unit-testing;in-memory;mock;development</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemoryConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemoryConfigSource.cs
@@ -91,7 +91,7 @@ public sealed class InMemoryConfigSource(
     /// <inheritdoc/>
     public async Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
     {
-        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken).ConfigureAwait(false);
+        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken, _logger).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemoryConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemoryConfigSource.cs
@@ -1,5 +1,6 @@
 using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
+using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 
@@ -45,10 +46,7 @@ public sealed class InMemoryConfigSource(
     /// <inheritdoc/>
     public Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         _logger.LogDebug("Getting configuration value for key '{Key}' from in-memory store", key);
 
@@ -66,10 +64,7 @@ public sealed class InMemoryConfigSource(
     /// <inheritdoc/>
     public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         _logger.LogDebug("Attempting to get configuration value for key '{Key}' from in-memory store", key);
 
@@ -90,29 +85,13 @@ public sealed class InMemoryConfigSource(
     /// <inheritdoc/>
     public async Task<T> GetConfigValueAsync<T>(string key, CancellationToken cancellationToken = default)
     {
-        var value = await GetConfigValueAsync(key, cancellationToken).ConfigureAwait(false);
-        return ConvertValue<T>(value, key);
+        return await ConfigSourceFacade.GetValueAsync<T>(GetConfigValueAsync, key, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var value = await TryGetConfigValueAsync(key, cancellationToken).ConfigureAwait(false);
-
-            if (value == null)
-            {
-                return defaultValue;
-            }
-
-            return ConvertValue<T>(value, key);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Error converting configuration key '{Key}', returning default value", key);
-            return defaultValue;
-        }
+        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -122,10 +101,7 @@ public sealed class InMemoryConfigSource(
     /// <param name="value">The configuration value.</param>
     public void SetConfigValue(string key, string value)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         ArgumentNullException.ThrowIfNull(value);
 
@@ -140,10 +116,7 @@ public sealed class InMemoryConfigSource(
     /// <returns>True if the value was removed, false if it did not exist.</returns>
     public bool RemoveConfigValue(string key)
     {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
-        }
+        ConfigSourceFacade.ValidateKey(key);
 
         var removed = _configValues.TryRemove(key, out _);
         if (removed)
@@ -161,34 +134,5 @@ public sealed class InMemoryConfigSource(
     {
         _configValues.Clear();
         _logger.LogDebug("All configuration values cleared from in-memory store");
-    }
-
-    private static T ConvertValue<T>(string value, string key)
-    {
-        try
-        {
-            var targetType = typeof(T);
-
-            if (targetType == typeof(string))
-            {
-                return (T)(object)value;
-            }
-
-            var converter = System.ComponentModel.TypeDescriptor.GetConverter(targetType);
-            if (converter.CanConvertFrom(typeof(string)))
-            {
-                var result = converter.ConvertFromInvariantString(value);
-                if (result != null)
-                {
-                    return (T)result;
-                }
-            }
-
-            throw new InvalidOperationException($"Cannot convert value to type {targetType.Name}");
-        }
-        catch (Exception ex)
-        {
-            throw new VaultOperationException($"Failed to convert configuration value for key '{key}' to type {typeof(T).Name}", ex);
-        }
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemorySecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemorySecretStore.cs
@@ -1,6 +1,7 @@
 using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
 
@@ -62,21 +63,7 @@ public sealed class InMemorySecretStore(
 
         _logger.LogDebug("Attempting to get secret '{SecretName}' from in-memory store", identifier.Name);
 
-        try
-        {
-            var secretValue = await GetSecretAsync(identifier, cancellationToken).ConfigureAwait(false);
-            return VaultResult.Success(secretValue);
-        }
-        catch (SecretNotFoundException ex)
-        {
-            _logger.LogDebug("Secret '{SecretName}' not found in in-memory store", identifier.Name);
-            return VaultResult.Failure<SecretValue>($"Secret '{identifier.Name}' not found: {ex.Message}");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error retrieving secret '{SecretName}' from in-memory store", identifier.Name);
-            return VaultResult.Failure<SecretValue>($"Failed to retrieve secret '{identifier.Name}': {ex.Message}");
-        }
+        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, _logger, "in-memory store", cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -157,19 +144,19 @@ public sealed class InMemorySecretStore(
     /// <inheritdoc/>
     public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
     {
-        return GetSecretAsync(new SecretIdentifier(key, version), cancellationToken);
+        return SecretStoreFacade.FetchSecretAsync(GetSecretAsync, key, version, cancellationToken);
     }
 
     /// <inheritdoc/>
     public async Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
     {
-        return await TryGetSecretAsync(new SecretIdentifier(key, version), cancellationToken).ConfigureAwait(false);
+        return await SecretStoreFacade.TryFetchSecretAsync(TryGetSecretAsync, key, version, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
     {
-        return ListSecretVersionsAsync(key, cancellationToken);
+        return SecretStoreFacade.ListVersionsAsync(ListSecretVersionsAsync, key, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -15,12 +15,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/ConfigSourceFacadeTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/ConfigSourceFacadeTests.cs
@@ -1,0 +1,49 @@
+using HoneyDrunk.Vault.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace HoneyDrunk.Vault.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ConfigSourceFacade"/>.
+/// </summary>
+public sealed class ConfigSourceFacadeTests
+{
+    /// <summary>
+    /// Verifies that try-get conversion returns the default value when conversion fails.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task TryGetValueAsync_ReturnsDefault_WhenConversionFails()
+    {
+        // Act
+        var result = await ConfigSourceFacade.TryGetValueAsync(
+            static (_, _) => Task.FromResult<string?>("not-an-int"),
+            "timeout",
+            30,
+            logger: NullLogger.Instance);
+
+        // Assert
+        Assert.Equal(30, result);
+    }
+
+    /// <summary>
+    /// Verifies that cooperative cancellation is not converted into a default value.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task TryGetValueAsync_RethrowsOperationCanceledException_WhenCancellationRequested()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            ConfigSourceFacade.TryGetValueAsync(
+                static (_, cancellationToken) => Task.FromCanceled<string?>(cancellationToken),
+                "timeout",
+                30,
+                cts.Token,
+                NullLogger.Instance));
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/SecretStoreFacadeTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/SecretStoreFacadeTests.cs
@@ -1,0 +1,33 @@
+using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace HoneyDrunk.Vault.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="SecretStoreFacade"/>.
+/// </summary>
+public sealed class SecretStoreFacadeTests
+{
+    /// <summary>
+    /// Verifies that cooperative cancellation is not converted into a failed Vault result.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Fact]
+    public async Task TryGetSecretAsync_RethrowsOperationCanceledException_WhenCancellationRequested()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var identifier = new SecretIdentifier("api-key");
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            SecretStoreFacade.TryGetSecretAsync(
+                identifier,
+                static (_, cancellationToken) => Task.FromCanceled<SecretValue>(cancellationToken),
+                NullLogger.Instance,
+                "test store",
+                cts.Token));
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-18
+
+### Changed
+- Aligned Vault package versions and Kernel references with `HoneyDrunk.Kernel`/`HoneyDrunk.Kernel.Abstractions` v0.7.0.
+- Centralized provider bootstrap configuration resolution, secret-store facade wrappers, and config-source value conversion/orchestration to reduce duplicate provider helper logic.
+
 ## [0.4.0] - 2026-05-04
 
 ### Added

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Configuration/BootstrapConfigurationResolver.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Configuration/BootstrapConfigurationResolver.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics.CodeAnalysis;
+
+namespace HoneyDrunk.Vault.Configuration;
+
+/// <summary>
+/// Resolves bootstrap configuration values shared by Vault provider packages.
+/// </summary>
+public static class BootstrapConfigurationResolver
+{
+    /// <summary>
+    /// Resolves an <see cref="IConfiguration"/> instance from the service collection or builds a fallback from environment variables.
+    /// </summary>
+    /// <param name="services">The service collection to inspect.</param>
+    /// <returns>The resolved configuration instance.</returns>
+    public static IConfiguration Resolve(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var descriptor = services.LastOrDefault(static d => d.ServiceType == typeof(IConfiguration));
+        if (descriptor?.ImplementationInstance is IConfiguration configuration)
+        {
+            return configuration;
+        }
+
+        return new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .Build();
+    }
+
+    /// <summary>
+    /// Determines whether the current environment is Development.
+    /// </summary>
+    /// <param name="configuration">The configuration to check.</param>
+    /// <param name="aspNetCoreEnvironmentSetting">The ASP.NET Core environment variable name.</param>
+    /// <param name="dotNetEnvironmentSetting">The .NET environment variable name.</param>
+    /// <returns><see langword="true"/> if the environment is Development; otherwise, <see langword="false"/>.</returns>
+    public static bool IsDevelopment(IConfiguration configuration, string aspNetCoreEnvironmentSetting, string dotNetEnvironmentSetting)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var environment = configuration[aspNetCoreEnvironmentSetting] ??
+            configuration[dotNetEnvironmentSetting] ??
+            Environment.GetEnvironmentVariable(aspNetCoreEnvironmentSetting) ??
+            Environment.GetEnvironmentVariable(dotNetEnvironmentSetting);
+
+        return string.Equals(environment, "Development", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Attempts to read an absolute URI from configuration or environment variables.
+    /// </summary>
+    /// <param name="configuration">The configuration to read from.</param>
+    /// <param name="settingName">The setting key name.</param>
+    /// <param name="uri">When this method returns, contains the parsed URI, or <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if a valid absolute URI was found; otherwise, <see langword="false"/>.</returns>
+    public static bool TryGetUri(IConfiguration configuration, string settingName, [NotNullWhen(true)] out Uri? uri)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var value = configuration[settingName];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            value = Environment.GetEnvironmentVariable(settingName);
+        }
+
+        var isValid = Uri.TryCreate(value, UriKind.Absolute, out var parsed);
+        uri = parsed;
+        return isValid;
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
@@ -10,10 +10,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault</PackageId>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
-    <Description>Secrets and configuration management library for .NET. Provides a unified abstraction for accessing secrets from multiple providers (File, Azure Key Vault, AWS Secrets Manager, Configuration, In-Memory). Integrated with HoneyDrunk.Kernel for lifecycle management, health reporting, and distributed telemetry.</Description>
-    <PackageReleaseNotes>v0.4.0: Added ADR-0026 tenant-scoped secret resolver and tenancy documentation. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <Description>Secrets and configuration management library for .NET. Provides a unified abstraction for accessing secrets from multiple providers (File, Azure Key Vault, AWS Secrets Manager, Configuration, In-Memory). Integrated with HoneyDrunk.Kernel v0.7.0 for lifecycle management, health reporting, and distributed telemetry.</Description>
+    <PackageReleaseNotes>v0.5.0: Align Kernel references to v0.7.0 and consolidate Vault provider bootstrap, secret-store facade, and config-source helpers. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;secrets;configuration;provider;cache;resilience;circuit-breaker;retry;azure-keyvault;aws;kernel;grid;distributed-tracing</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -27,15 +27,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.5.0" />
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.7.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Resilience" Version="10.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Resilience" Version="10.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/CompositeConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/CompositeConfigSource.cs
@@ -91,7 +91,7 @@ public sealed class CompositeConfigSource : IConfigSource, IConfigProvider
     /// <inheritdoc/>
     public async Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
     {
-        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken).ConfigureAwait(false);
+        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken, _logger).ConfigureAwait(false);
     }
 
     // IConfigProvider implementation - delegates to IConfigSource methods

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/CompositeConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/CompositeConfigSource.cs
@@ -85,32 +85,13 @@ public sealed class CompositeConfigSource : IConfigSource, IConfigProvider
     /// <inheritdoc/>
     public async Task<T> GetConfigValueAsync<T>(string key, CancellationToken cancellationToken = default)
     {
-        var stringValue = await GetConfigValueAsync(key, cancellationToken).ConfigureAwait(false);
-        return ConvertValue<T>(stringValue, key);
+        return await ConfigSourceFacade.GetValueAsync<T>(GetConfigValueAsync, key, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public async Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
     {
-        var stringValue = await TryGetConfigValueAsync(key, cancellationToken).ConfigureAwait(false);
-
-        if (stringValue == null)
-        {
-            return defaultValue;
-        }
-
-        try
-        {
-            return ConvertValue<T>(stringValue, key);
-        }
-        catch
-        {
-            _logger.LogWarning(
-                "Failed to convert configuration value for key '{Key}' to type '{Type}', returning default",
-                key,
-                typeof(T).Name);
-            return defaultValue;
-        }
+        return await ConfigSourceFacade.TryGetValueAsync(TryGetConfigValueAsync, key, defaultValue, cancellationToken).ConfigureAwait(false);
     }
 
     // IConfigProvider implementation - delegates to IConfigSource methods
@@ -137,84 +118,6 @@ public sealed class CompositeConfigSource : IConfigSource, IConfigProvider
     Task<T> IConfigProvider.GetValueAsync<T>(string key, CancellationToken cancellationToken)
     {
         return GetConfigValueAsync<T>(key, cancellationToken);
-    }
-
-    private static T ConvertValue<T>(string value, string key)
-    {
-        try
-        {
-            var targetType = typeof(T);
-
-            if (targetType == typeof(string))
-            {
-                return (T)(object)value;
-            }
-
-            if (targetType == typeof(int))
-            {
-                return (T)(object)int.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-
-            if (targetType == typeof(long))
-            {
-                return (T)(object)long.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-
-            if (targetType == typeof(double))
-            {
-                return (T)(object)double.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-
-            if (targetType == typeof(decimal))
-            {
-                return (T)(object)decimal.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-
-            if (targetType == typeof(bool))
-            {
-                return (T)(object)bool.Parse(value);
-            }
-
-            if (targetType == typeof(Guid))
-            {
-                return (T)(object)Guid.Parse(value);
-            }
-
-            if (targetType == typeof(TimeSpan))
-            {
-                return (T)(object)TimeSpan.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-
-            if (targetType == typeof(DateTime))
-            {
-                return (T)(object)DateTime.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-
-            if (targetType == typeof(DateTimeOffset))
-            {
-                return (T)(object)DateTimeOffset.Parse(value, System.Globalization.CultureInfo.InvariantCulture);
-            }
-
-            if (targetType == typeof(Uri))
-            {
-                return (T)(object)new Uri(value);
-            }
-
-            // Try using the type converter as a fallback (invariant culture for consistency)
-            var converter = System.ComponentModel.TypeDescriptor.GetConverter(targetType);
-            if (converter.CanConvertFrom(typeof(string)))
-            {
-                return (T)converter.ConvertFromInvariantString(value)!;
-            }
-
-            throw new InvalidOperationException($"Cannot convert string to type {targetType.Name}");
-        }
-        catch (Exception ex) when (ex is not InvalidOperationException)
-        {
-            throw new VaultOperationException(
-                $"Failed to convert configuration value for key '{key}' to type {typeof(T).Name}",
-                ex);
-        }
     }
 
     /// <summary>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/ConfigSourceFacade.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/ConfigSourceFacade.cs
@@ -1,4 +1,5 @@
 using HoneyDrunk.Vault.Exceptions;
+using Microsoft.Extensions.Logging;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text.Json;
@@ -93,12 +94,14 @@ public static class ConfigSourceFacade
     /// <param name="key">The configuration key.</param>
     /// <param name="defaultValue">The fallback value.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="logger">The optional logger.</param>
     /// <returns>The converted value, or <paramref name="defaultValue"/> when missing or invalid.</returns>
     public static async Task<T> TryGetValueAsync<T>(
         Func<string, CancellationToken, Task<string?>> tryGetValueAsync,
         string key,
         T defaultValue,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(tryGetValueAsync);
 
@@ -107,8 +110,13 @@ public static class ConfigSourceFacade
             var value = await tryGetValueAsync(key, cancellationToken).ConfigureAwait(false);
             return value == null ? defaultValue : ConvertValue<T>(value, key);
         }
-        catch
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Failed to convert configuration value for key '{Key}' to type '{Type}', returning default", key, typeof(T).Name);
             return defaultValue;
         }
     }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/ConfigSourceFacade.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/ConfigSourceFacade.cs
@@ -1,0 +1,115 @@
+using HoneyDrunk.Vault.Exceptions;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text.Json;
+
+namespace HoneyDrunk.Vault.Services;
+
+/// <summary>
+/// Shared helper methods for configuration source implementations.
+/// </summary>
+public static class ConfigSourceFacade
+{
+    /// <summary>
+    /// Validates a configuration key.
+    /// </summary>
+    /// <param name="key">The key to validate.</param>
+    /// <exception cref="ArgumentException">Thrown when the key is null or whitespace.</exception>
+    public static void ValidateKey(string key)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("Key cannot be null or whitespace.", nameof(key));
+        }
+    }
+
+    /// <summary>
+    /// Converts a string configuration value to the requested type.
+    /// </summary>
+    /// <typeparam name="T">The target type.</typeparam>
+    /// <param name="value">The value to convert.</param>
+    /// <param name="key">The configuration key, used in error messages.</param>
+    /// <returns>The converted value.</returns>
+    public static T ConvertValue<T>(string value, string key)
+    {
+        try
+        {
+            var targetType = typeof(T);
+            var effectiveType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+            if (effectiveType == typeof(string))
+            {
+                return (T)(object)value;
+            }
+
+            if (effectiveType.IsEnum)
+            {
+                return (T)Enum.Parse(effectiveType, value, ignoreCase: true);
+            }
+
+            var converter = TypeDescriptor.GetConverter(effectiveType);
+            if (converter.CanConvertFrom(typeof(string)))
+            {
+                var result = converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
+                if (result != null)
+                {
+                    return (T)result;
+                }
+            }
+
+            return JsonSerializer.Deserialize<T>(value)
+                ?? throw new InvalidOperationException($"Failed to deserialize configuration value for key '{key}'");
+        }
+        catch (Exception ex)
+        {
+            throw new VaultOperationException($"Failed to convert configuration value for key '{key}' to type '{typeof(T).Name}'", ex);
+        }
+    }
+
+    /// <summary>
+    /// Gets and converts a typed configuration value.
+    /// </summary>
+    /// <typeparam name="T">The target type.</typeparam>
+    /// <param name="getValueAsync">The string-value getter.</param>
+    /// <param name="key">The configuration key.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The converted value.</returns>
+    public static async Task<T> GetValueAsync<T>(
+        Func<string, CancellationToken, Task<string>> getValueAsync,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(getValueAsync);
+
+        var value = await getValueAsync(key, cancellationToken).ConfigureAwait(false);
+        return ConvertValue<T>(value, key);
+    }
+
+    /// <summary>
+    /// Tries to get and convert a typed configuration value.
+    /// </summary>
+    /// <typeparam name="T">The target type.</typeparam>
+    /// <param name="tryGetValueAsync">The nullable string-value getter.</param>
+    /// <param name="key">The configuration key.</param>
+    /// <param name="defaultValue">The fallback value.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The converted value, or <paramref name="defaultValue"/> when missing or invalid.</returns>
+    public static async Task<T> TryGetValueAsync<T>(
+        Func<string, CancellationToken, Task<string?>> tryGetValueAsync,
+        string key,
+        T defaultValue,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(tryGetValueAsync);
+
+        try
+        {
+            var value = await tryGetValueAsync(key, cancellationToken).ConfigureAwait(false);
+            return value == null ? defaultValue : ConvertValue<T>(value, key);
+        }
+        catch
+        {
+            return defaultValue;
+        }
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/SecretStoreFacade.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/SecretStoreFacade.cs
@@ -1,0 +1,107 @@
+using HoneyDrunk.Vault.Exceptions;
+using HoneyDrunk.Vault.Models;
+using Microsoft.Extensions.Logging;
+
+namespace HoneyDrunk.Vault.Services;
+
+/// <summary>
+/// Shared facade helpers for secret stores that also expose provider-style APIs.
+/// </summary>
+public static class SecretStoreFacade
+{
+    /// <summary>
+    /// Fetches a secret by provider key through a secret-store delegate.
+    /// </summary>
+    /// <param name="getSecretAsync">The store get delegate.</param>
+    /// <param name="key">The secret key.</param>
+    /// <param name="version">The optional secret version.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The secret value.</returns>
+    public static Task<SecretValue> FetchSecretAsync(
+        Func<SecretIdentifier, CancellationToken, Task<SecretValue>> getSecretAsync,
+        string key,
+        string? version = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(getSecretAsync);
+
+        return getSecretAsync(new SecretIdentifier(key, version), cancellationToken);
+    }
+
+    /// <summary>
+    /// Attempts a get-secret operation and converts common Vault exceptions to a failed result.
+    /// </summary>
+    /// <param name="identifier">The secret identifier.</param>
+    /// <param name="getSecretAsync">The store get delegate.</param>
+    /// <param name="logger">The optional logger.</param>
+    /// <param name="storeName">The store name used in log messages.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the secret or failure details.</returns>
+    public static async Task<VaultResult<SecretValue>> TryGetSecretAsync(
+        SecretIdentifier identifier,
+        Func<SecretIdentifier, CancellationToken, Task<SecretValue>> getSecretAsync,
+        ILogger? logger = null,
+        string? storeName = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(identifier);
+        ArgumentNullException.ThrowIfNull(getSecretAsync);
+
+        try
+        {
+            var secretValue = await getSecretAsync(identifier, cancellationToken).ConfigureAwait(false);
+            return VaultResult.Success(secretValue);
+        }
+        catch (SecretNotFoundException ex)
+        {
+            logger?.LogDebug("Secret '{SecretName}' not found in {StoreName}", identifier.Name, storeName ?? "secret store");
+            return VaultResult.Failure<SecretValue>($"Secret '{identifier.Name}' not found: {ex.Message}");
+        }
+        catch (VaultOperationException ex)
+        {
+            logger?.LogError(ex, "Vault operation failed retrieving secret '{SecretName}' from {StoreName}", identifier.Name, storeName ?? "secret store");
+            return VaultResult.Failure<SecretValue>(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Error retrieving secret '{SecretName}' from {StoreName}", identifier.Name, storeName ?? "secret store");
+            return VaultResult.Failure<SecretValue>($"Failed to retrieve secret '{identifier.Name}': {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Attempts to fetch a secret by provider key through a secret-store try delegate.
+    /// </summary>
+    /// <param name="tryGetSecretAsync">The store try-get delegate.</param>
+    /// <param name="key">The secret key.</param>
+    /// <param name="version">The optional secret version.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the secret or failure details.</returns>
+    public static Task<VaultResult<SecretValue>> TryFetchSecretAsync(
+        Func<SecretIdentifier, CancellationToken, Task<VaultResult<SecretValue>>> tryGetSecretAsync,
+        string key,
+        string? version = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(tryGetSecretAsync);
+
+        return tryGetSecretAsync(new SecretIdentifier(key, version), cancellationToken);
+    }
+
+    /// <summary>
+    /// Lists secret versions through a secret-store delegate.
+    /// </summary>
+    /// <param name="listSecretVersionsAsync">The store list-versions delegate.</param>
+    /// <param name="key">The secret key.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The secret versions.</returns>
+    public static Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(
+        Func<string, CancellationToken, Task<IReadOnlyList<SecretVersion>>> listSecretVersionsAsync,
+        string key,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(listSecretVersionsAsync);
+
+        return listSecretVersionsAsync(key, cancellationToken);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/SecretStoreFacade.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/SecretStoreFacade.cs
@@ -62,6 +62,10 @@ public static class SecretStoreFacade
             logger?.LogError(ex, "Vault operation failed retrieving secret '{SecretName}' from {StoreName}", identifier.Name, storeName ?? "secret store");
             return VaultResult.Failure<SecretValue>(ex.Message);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger?.LogError(ex, "Error retrieving secret '{SecretName}' from {StoreName}", identifier.Name, storeName ?? "secret store");


### PR DESCRIPTION
## Summary
- Align Vault solution package versions and Kernel references to `HoneyDrunk.Kernel`/`HoneyDrunk.Kernel.Abstractions` `0.7.0`.
- Consolidate duplicated Vault provider helper logic behind shared bootstrap, secret-store facade, and config-source facade helpers.
- Update repo/package changelogs, package release notes, and release-notes package coverage for the `0.5.0` release.

## Issue packets / tracking
- Closes #31
- Closes #29
- Packet: `generated/issue-packets/active/kernel-adoption-alignment/03-vault-align-kernel-version.md`
- Packet: `generated/issue-packets/active/standalone/2026-05-04-vault-consolidate-vault-provider-helpers.md`

## Release hygiene
- Verified `v0.4.0` exists as local and remote Git tag.
- Verified current NuGet packages include `0.4.0` for `HoneyDrunk.Vault`, provider packages, and `HoneyDrunk.Vault.EventGrid`.
- Bumped all non-test projects in the solution to `0.5.0` and updated repo-level + package changelogs.
- Added `HoneyDrunk.Vault.EventGrid` to publish release-note package coverage.

## Repo-wide scan notes
- Additional issue found outside original packet scope: publish release notes omitted `HoneyDrunk.Vault.EventGrid`; fixed in this PR.
- Architecture catalog compatibility still advertises Vault currentVersion `0.4.0`; that should be reconciled by Architecture/Hive sync after this PR lands and release tagging is approved.

## Validation
- `dotnet restore HoneyDrunk.Vault\HoneyDrunk.Vault.slnx --ignore-failed-sources` passed with Azure Artifacts vulnerability-feed `NU1900` warnings.
- `dotnet build HoneyDrunk.Vault\HoneyDrunk.Vault.slnx --no-restore` passed with the same `NU1900` warnings.
- `dotnet test HoneyDrunk.Vault\HoneyDrunk.Vault.slnx --no-build --no-restore` passed: 190/190.
- `git diff --check` passed; only LF→CRLF warnings reported by Git.
