### PR TITLE
test: backfill Vault coverage gate

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,8 @@ name: PR
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 
 permissions:
   contents: read
@@ -10,6 +12,7 @@ permissions:
 jobs:
   pr-core:
     name: PR Core
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       checks: write
@@ -24,7 +27,26 @@ jobs:
       project-path: 'HoneyDrunk.Vault.slnx'
       enable-secret-scan: true
       enable-accessibility-check: false
+      patch-coverage-threshold: 75
+      absolute-coverage-floor: 70
       post-pr-summary: true
+      actions-ref: 'main'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  coverage-baseline-ratchet:
+    name: Coverage Baseline Ratchet
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+      checks: write
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/coverage-baseline-ratchet.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      configuration: 'Release'
+      runs-on: 'ubuntu-latest'
+      working-directory: 'HoneyDrunk.Vault'
+      project-path: 'HoneyDrunk.Vault.slnx'
       actions-ref: 'main'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ _TeamCity*
 
 # Coverlet is a free, cross platform Code Coverage Tool
 coverage*.json
+!**/.github/coverage-baseline.json
 coverage*.xml
 coverage*.info
 

--- a/HoneyDrunk.Vault/.github/coverage-baseline.json
+++ b/HoneyDrunk.Vault/.github/coverage-baseline.json
@@ -1,0 +1,5 @@
+{
+  "totalLineCoverage": 71.8,
+  "commit": "pending-merge",
+  "measuredAtUtc": "2026-05-19T15:55:57Z"
+}

--- a/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Internal
+- Backfilled Vault test coverage above the Grid PR coverage gate floor and seeded the coverage baseline ratchet artifact.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Health/VaultHealthContributorTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Health/VaultHealthContributorTests.cs
@@ -1,0 +1,221 @@
+using HoneyDrunk.Kernel.Abstractions.Health;
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Configuration;
+using HoneyDrunk.Vault.Health;
+using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace HoneyDrunk.Vault.Tests.Health;
+
+/// <summary>
+/// Tests for <see cref="VaultHealthContributor"/> provider aggregation behavior.
+/// </summary>
+public sealed class VaultHealthContributorTests
+{
+    /// <summary>
+    /// Verifies contributor metadata remains stable for lifecycle ordering.
+    /// </summary>
+    [Fact]
+    public void Metadata_ReturnsExpectedValues()
+    {
+        // Arrange
+        var contributor = CreateContributor([], []);
+
+        // Assert
+        Assert.Equal("HoneyDrunk.Vault", contributor.Name);
+        Assert.Equal(100, contributor.Priority);
+        Assert.True(contributor.IsCritical);
+    }
+
+    /// <summary>
+    /// Verifies no configured providers report a degraded health state.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenNoProvidersConfigured()
+    {
+        // Arrange
+        var contributor = CreateContributor([], []);
+
+        // Act
+        var (status, message) = await contributor.CheckHealthAsync();
+
+        // Assert
+        Assert.Equal(HealthStatus.Degraded, status);
+        Assert.Equal("No vault providers configured", message);
+    }
+
+    /// <summary>
+    /// Verifies all healthy providers produce a healthy result with de-duplicated provider names.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsHealthy_WhenAllEnabledProvidersAreHealthy()
+    {
+        // Arrange
+        var secret = new TestSecretProvider("shared", isHealthy: true);
+        var config = new TestConfigProvider("shared", isHealthy: true);
+        var contributor = CreateContributor(
+            [RegisterSecret(secret)],
+            [RegisterConfig(config)]);
+
+        // Act
+        var (status, message) = await contributor.CheckHealthAsync();
+
+        // Assert
+        Assert.Equal(HealthStatus.Healthy, status);
+        Assert.Equal("All providers healthy: shared", message);
+        Assert.Equal(1, secret.HealthChecks);
+        Assert.Equal(1, config.HealthChecks);
+    }
+
+    /// <summary>
+    /// Verifies mixed provider health reports degraded rather than unhealthy.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenSomeProvidersAreUnhealthy()
+    {
+        // Arrange
+        var contributor = CreateContributor(
+            [RegisterSecret(new TestSecretProvider("healthy", isHealthy: true))],
+            [RegisterConfig(new TestConfigProvider("unhealthy", isHealthy: false))]);
+
+        // Act
+        var (status, message) = await contributor.CheckHealthAsync();
+
+        // Assert
+        Assert.Equal(HealthStatus.Degraded, status);
+        Assert.Equal("Healthy: healthy; Unhealthy: unhealthy", message);
+    }
+
+    /// <summary>
+    /// Verifies all unhealthy providers report an unhealthy state.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsUnhealthy_WhenNoEnabledProviderIsHealthy()
+    {
+        // Arrange
+        var contributor = CreateContributor(
+            [RegisterSecret(new TestSecretProvider("down", isHealthy: false))],
+            [RegisterConfig(new TestConfigProvider("throwing", exception: new InvalidOperationException("boom")))]);
+
+        // Act
+        var (status, message) = await contributor.CheckHealthAsync();
+
+        // Assert
+        Assert.Equal(HealthStatus.Unhealthy, status);
+        Assert.Equal("All providers unhealthy: down, throwing", message);
+    }
+
+    /// <summary>
+    /// Verifies disabled providers are not probed during health checks.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckHealthAsync_IgnoresDisabledProviders()
+    {
+        // Arrange
+        var disabled = new TestSecretProvider("disabled", isHealthy: false);
+        var enabled = new TestConfigProvider("enabled", isHealthy: true);
+        var contributor = CreateContributor(
+            [RegisterSecret(disabled, enabled: false)],
+            [RegisterConfig(enabled)]);
+
+        // Act
+        var (status, message) = await contributor.CheckHealthAsync();
+
+        // Assert
+        Assert.Equal(HealthStatus.Healthy, status);
+        Assert.Equal("All providers healthy: enabled", message);
+        Assert.Equal(0, disabled.HealthChecks);
+        Assert.Equal(1, enabled.HealthChecks);
+    }
+
+    private static VaultHealthContributor CreateContributor(
+        IEnumerable<RegisteredSecretProvider> secretProviders,
+        IEnumerable<RegisteredConfigSourceProvider> configProviders)
+    {
+        return new VaultHealthContributor(
+            secretProviders,
+            configProviders,
+            NullLogger<VaultHealthContributor>.Instance);
+    }
+
+    private static RegisteredSecretProvider RegisterSecret(TestSecretProvider provider, bool enabled = true)
+    {
+        return new RegisteredSecretProvider(provider, new ProviderRegistration { Name = provider.ProviderName, IsEnabled = enabled });
+    }
+
+    private static RegisteredConfigSourceProvider RegisterConfig(TestConfigProvider provider, bool enabled = true)
+    {
+        return new RegisteredConfigSourceProvider(provider, new ProviderRegistration { Name = provider.ProviderName, IsEnabled = enabled });
+    }
+
+    private sealed class TestSecretProvider(string providerName, bool isHealthy = true, Exception? exception = null) : ISecretProvider
+    {
+        public string ProviderName { get; } = providerName;
+
+        public bool IsAvailable => isHealthy;
+
+        public int HealthChecks { get; private set; }
+
+        public Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default)
+        {
+            HealthChecks++;
+            return exception is null ? Task.FromResult(isHealthy) : Task.FromException<bool>(exception);
+        }
+
+        public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class TestConfigProvider(string providerName, bool isHealthy = true, Exception? exception = null) : IConfigSourceProvider
+    {
+        public string ProviderName { get; } = providerName;
+
+        public bool IsAvailable => isHealthy;
+
+        public int HealthChecks { get; private set; }
+
+        public Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default)
+        {
+            HealthChecks++;
+            return exception is null ? Task.FromResult(isHealthy) : Task.FromException<bool>(exception);
+        }
+
+        public Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<T> GetConfigValueAsync<T>(string key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Health/VaultReadinessContributorTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Health/VaultReadinessContributorTests.cs
@@ -1,0 +1,256 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Configuration;
+using HoneyDrunk.Vault.Health;
+using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace HoneyDrunk.Vault.Tests.Health;
+
+/// <summary>
+/// Tests for <see cref="VaultReadinessContributor"/> required-provider readiness semantics.
+/// </summary>
+public sealed class VaultReadinessContributorTests
+{
+    /// <summary>
+    /// Verifies contributor metadata remains stable for lifecycle ordering.
+    /// </summary>
+    [Fact]
+    public void Metadata_ReturnsExpectedValues()
+    {
+        // Arrange
+        var contributor = CreateContributor([], []);
+
+        // Assert
+        Assert.Equal("HoneyDrunk.Vault", contributor.Name);
+        Assert.Equal(100, contributor.Priority);
+        Assert.True(contributor.IsRequired);
+    }
+
+    /// <summary>
+    /// Verifies no configured providers is treated as ready but reported explicitly.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckReadinessAsync_ReturnsReady_WhenNoProvidersConfigured()
+    {
+        // Arrange
+        var contributor = CreateContributor([], []);
+
+        // Act
+        var (ready, message) = await contributor.CheckReadinessAsync();
+
+        // Assert
+        Assert.True(ready);
+        Assert.Equal("Vault ready (no providers configured)", message);
+    }
+
+    /// <summary>
+    /// Verifies any required unhealthy provider fails readiness.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckReadinessAsync_ReturnsNotReady_WhenRequiredProviderIsUnhealthy()
+    {
+        // Arrange
+        var contributor = CreateContributor(
+            [RegisterSecret(new TestSecretProvider("required-down", isHealthy: false), required: true)],
+            [RegisterConfig(new TestConfigProvider("optional-up", isHealthy: true))]);
+
+        // Act
+        var (ready, message) = await contributor.CheckReadinessAsync();
+
+        // Assert
+        Assert.False(ready);
+        Assert.Equal("Required providers not ready: required-down", message);
+    }
+
+    /// <summary>
+    /// Verifies required provider exceptions fail readiness and keep checking other enabled providers.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckReadinessAsync_ReturnsNotReady_WhenRequiredProviderThrows()
+    {
+        // Arrange
+        var optional = new TestConfigProvider("optional-up", isHealthy: true);
+        var contributor = CreateContributor(
+            [RegisterSecret(new TestSecretProvider("required-throwing", exception: new InvalidOperationException("boom")), required: true)],
+            [RegisterConfig(optional)]);
+
+        // Act
+        var (ready, message) = await contributor.CheckReadinessAsync();
+
+        // Assert
+        Assert.False(ready);
+        Assert.Equal("Required providers not ready: required-throwing", message);
+        Assert.Equal(1, optional.HealthChecks);
+    }
+
+    /// <summary>
+    /// Verifies optional outages are reported while readiness succeeds when another provider is ready.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckReadinessAsync_ReturnsReadyWithUnavailableProviders_WhenOnlyOptionalProvidersAreDown()
+    {
+        // Arrange
+        var contributor = CreateContributor(
+            [RegisterSecret(new TestSecretProvider("ready", isHealthy: true))],
+            [RegisterConfig(new TestConfigProvider("optional-down", isHealthy: false))]);
+
+        // Act
+        var (ready, message) = await contributor.CheckReadinessAsync();
+
+        // Assert
+        Assert.True(ready);
+        Assert.Equal("Ready: ready; Unavailable: optional-down", message);
+    }
+
+    /// <summary>
+    /// Verifies duplicated provider names are de-duplicated across secret and config providers.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckReadinessAsync_DeDuplicatesProviderNamesAcrossProviderKinds()
+    {
+        // Arrange
+        var contributor = CreateContributor(
+            [RegisterSecret(new TestSecretProvider("shared", isHealthy: true))],
+            [RegisterConfig(new TestConfigProvider("shared", isHealthy: false), required: true)]);
+
+        // Act
+        var (ready, message) = await contributor.CheckReadinessAsync();
+
+        // Assert
+        Assert.False(ready);
+        Assert.Equal("Required providers not ready: shared", message);
+    }
+
+    /// <summary>
+    /// Verifies disabled providers are not probed for readiness.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckReadinessAsync_IgnoresDisabledProviders()
+    {
+        // Arrange
+        var disabled = new TestSecretProvider("disabled", isHealthy: false);
+        var contributor = CreateContributor(
+            [RegisterSecret(disabled, enabled: false, required: true)],
+            []);
+
+        // Act
+        var (ready, message) = await contributor.CheckReadinessAsync();
+
+        // Assert
+        Assert.True(ready);
+        Assert.Equal("Vault ready (no providers configured)", message);
+        Assert.Equal(0, disabled.HealthChecks);
+    }
+
+    /// <summary>
+    /// Verifies no providers ready reports not ready.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckReadinessAsync_ReturnsNotReady_WhenNoEnabledProviderIsReady()
+    {
+        // Arrange
+        var contributor = CreateContributor(
+            [RegisterSecret(new TestSecretProvider("optional-down", isHealthy: false))],
+            []);
+
+        // Act
+        var (ready, message) = await contributor.CheckReadinessAsync();
+
+        // Assert
+        Assert.False(ready);
+        Assert.Equal("No providers available", message);
+    }
+
+    private static VaultReadinessContributor CreateContributor(
+        IEnumerable<RegisteredSecretProvider> secretProviders,
+        IEnumerable<RegisteredConfigSourceProvider> configProviders)
+    {
+        return new VaultReadinessContributor(
+            secretProviders,
+            configProviders,
+            NullLogger<VaultReadinessContributor>.Instance);
+    }
+
+    private static RegisteredSecretProvider RegisterSecret(TestSecretProvider provider, bool enabled = true, bool required = false)
+    {
+        return new RegisteredSecretProvider(provider, new ProviderRegistration { Name = provider.ProviderName, IsEnabled = enabled, IsRequired = required });
+    }
+
+    private static RegisteredConfigSourceProvider RegisterConfig(TestConfigProvider provider, bool enabled = true, bool required = false)
+    {
+        return new RegisteredConfigSourceProvider(provider, new ProviderRegistration { Name = provider.ProviderName, IsEnabled = enabled, IsRequired = required });
+    }
+
+    private sealed class TestSecretProvider(string providerName, bool isHealthy = true, Exception? exception = null) : ISecretProvider
+    {
+        public string ProviderName { get; } = providerName;
+
+        public bool IsAvailable => isHealthy;
+
+        public int HealthChecks { get; private set; }
+
+        public Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default)
+        {
+            HealthChecks++;
+            return exception is null ? Task.FromResult(isHealthy) : Task.FromException<bool>(exception);
+        }
+
+        public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class TestConfigProvider(string providerName, bool isHealthy = true, Exception? exception = null) : IConfigSourceProvider
+    {
+        public string ProviderName { get; } = providerName;
+
+        public bool IsAvailable => isHealthy;
+
+        public int HealthChecks { get; private set; }
+
+        public Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default)
+        {
+            HealthChecks++;
+            return exception is null ? Task.FromResult(isHealthy) : Task.FromException<bool>(exception);
+        }
+
+        public Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<T> GetConfigValueAsync<T>(string key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Lifecycle/VaultStartupHookTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Lifecycle/VaultStartupHookTests.cs
@@ -1,0 +1,176 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Configuration;
+using HoneyDrunk.Vault.Lifecycle;
+using HoneyDrunk.Vault.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Vault.Tests.Lifecycle;
+
+/// <summary>
+/// Tests for <see cref="VaultStartupHook"/> configuration validation and cache warmup.
+/// </summary>
+public sealed class VaultStartupHookTests
+{
+    /// <summary>
+    /// Verifies startup metadata remains stable for lifecycle ordering.
+    /// </summary>
+    [Fact]
+    public void Priority_ReturnsExpectedValue()
+    {
+        // Arrange
+        var hook = CreateHook(new VaultOptions(), new TestSecretStore());
+
+        // Assert
+        Assert.Equal(100, hook.Priority);
+    }
+
+    /// <summary>
+    /// Verifies startup succeeds when no providers are configured.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExecuteAsync_Completes_WhenNoProvidersConfigured()
+    {
+        // Arrange
+        var store = new TestSecretStore();
+        var hook = CreateHook(new VaultOptions(), store);
+
+        // Act
+        await hook.ExecuteAsync();
+
+        // Assert
+        Assert.Empty(store.RequestedSecrets);
+    }
+
+    /// <summary>
+    /// Verifies Azure Key Vault provider validation requires a VaultUri setting.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExecuteAsync_Throws_WhenAzureKeyVaultProviderHasNoVaultUri()
+    {
+        // Arrange
+        var options = new VaultOptions();
+        options.AddProvider("akv", provider =>
+        {
+            provider.ProviderType = ProviderType.AzureKeyVault;
+            provider.IsEnabled = true;
+        });
+        var hook = CreateHook(options, new TestSecretStore());
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => hook.ExecuteAsync());
+        Assert.Contains("requires VaultUri", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies disabled providers are skipped by startup validation.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExecuteAsync_SkipsValidation_ForDisabledProviders()
+    {
+        // Arrange
+        var options = new VaultOptions();
+        options.AddProvider("akv", provider =>
+        {
+            provider.ProviderType = ProviderType.AzureKeyVault;
+            provider.IsEnabled = false;
+        });
+        var hook = CreateHook(options, new TestSecretStore());
+
+        // Act
+        await hook.ExecuteAsync();
+    }
+
+    /// <summary>
+    /// Verifies provider-specific optional settings do not block startup.
+    /// </summary>
+    /// <param name="providerType">The provider type to validate.</param>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Theory]
+    [InlineData(ProviderType.AwsSecretsManager)]
+    [InlineData(ProviderType.File)]
+    [InlineData(ProviderType.InMemory)]
+    [InlineData(ProviderType.Configuration)]
+    public async Task ExecuteAsync_Completes_ForProvidersWithoutRequiredSettings(ProviderType providerType)
+    {
+        // Arrange
+        var options = new VaultOptions();
+        options.AddProvider("provider", provider =>
+        {
+            provider.ProviderType = providerType;
+            provider.IsEnabled = true;
+        });
+        var hook = CreateHook(options, new TestSecretStore());
+
+        // Act
+        await hook.ExecuteAsync();
+    }
+
+    /// <summary>
+    /// Verifies startup warms each configured secret key.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExecuteAsync_WarmsConfiguredKeys()
+    {
+        // Arrange
+        var options = new VaultOptions();
+        options.WarmupKeys.AddRange(["api-key", "missing", "throwing"]);
+        var store = new TestSecretStore(
+            successNames: ["api-key"],
+            exceptionNames: ["throwing"]);
+        var hook = CreateHook(options, store);
+
+        // Act
+        await hook.ExecuteAsync();
+
+        // Assert
+        Assert.Equal(["api-key", "missing", "throwing"], store.RequestedSecrets);
+    }
+
+    private static VaultStartupHook CreateHook(VaultOptions options, ISecretStore store)
+    {
+        return new VaultStartupHook(
+            store,
+            Options.Create(options),
+            NullLogger<VaultStartupHook>.Instance);
+    }
+
+    private sealed class TestSecretStore(IEnumerable<string>? successNames = null, IEnumerable<string>? exceptionNames = null) : ISecretStore
+    {
+        private readonly HashSet<string> _successNames = successNames?.ToHashSet(StringComparer.Ordinal) ?? [];
+        private readonly HashSet<string> _exceptionNames = exceptionNames?.ToHashSet(StringComparer.Ordinal) ?? [];
+
+        public List<string> RequestedSecrets { get; } = [];
+
+        public Task<SecretValue> GetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
+        {
+            RequestedSecrets.Add(identifier.Name);
+
+            if (_exceptionNames.Contains(identifier.Name))
+            {
+                throw new InvalidOperationException("warmup failed");
+            }
+
+            if (!_successNames.Contains(identifier.Name))
+            {
+                return Task.FromResult(VaultResult.Failure<SecretValue>("not found"));
+            }
+
+            return Task.FromResult(VaultResult.Success(new SecretValue(identifier, "value", identifier.Version)));
+        }
+
+        public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/CompositeConfigSourceAdditionalTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/CompositeConfigSourceAdditionalTests.cs
@@ -1,0 +1,226 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Configuration;
+using HoneyDrunk.Vault.Exceptions;
+using HoneyDrunk.Vault.Resilience;
+using HoneyDrunk.Vault.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace HoneyDrunk.Vault.Tests.Services;
+
+/// <summary>
+/// Additional tests for <see cref="CompositeConfigSource"/> fallback and provider behavior.
+/// </summary>
+public sealed class CompositeConfigSourceAdditionalTests
+{
+    /// <summary>
+    /// Verifies constructor filters disabled and unavailable providers then orders by priority.
+    /// </summary>
+    [Fact]
+    public void Constructor_FiltersAndOrdersProviders()
+    {
+        // Arrange
+        var low = new TestConfigProvider("low", "low-value");
+        var high = new TestConfigProvider("high", "high-value");
+        var disabled = new TestConfigProvider("disabled", "disabled-value");
+        var unavailable = new TestConfigProvider("unavailable", "unavailable-value", isAvailable: false);
+
+        // Act
+        var source = CreateSource([
+            Register(low, priority: 100),
+            Register(high, priority: 1),
+            Register(disabled, enabled: false),
+            Register(unavailable)]);
+
+        // Assert
+        Assert.Equal(["high", "low"], source.Providers.Select(p => p.Provider.ProviderName));
+    }
+
+    /// <summary>
+    /// Verifies string lookups return the first value found by priority order.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetConfigValueAsync_ReturnsHighestPriorityProviderValue()
+    {
+        // Arrange
+        var source = CreateSource([
+            Register(new TestConfigProvider("low", "low-value"), priority: 100),
+            Register(new TestConfigProvider("high", "high-value"), priority: 1)]);
+
+        // Act
+        var value = await source.GetConfigValueAsync("feature:name");
+
+        // Assert
+        Assert.Equal("high-value", value);
+    }
+
+    /// <summary>
+    /// Verifies optional not-found and transient failures fall through to lower-priority providers.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task TryGetConfigValueAsync_FallsBack_WhenOptionalProvidersMissOrFailTransiently()
+    {
+        // Arrange
+        var missing = new TestConfigProvider("missing", exception: new ConfigurationNotFoundException("setting"));
+        var transient = new TestConfigProvider("transient", exception: new TimeoutException("timeout"));
+        var fallback = new TestConfigProvider("fallback", "fallback-value");
+        var source = CreateSource([
+            Register(missing, priority: 1),
+            Register(transient, priority: 2),
+            Register(fallback, priority: 3)]);
+
+        // Act
+        var value = await source.TryGetConfigValueAsync("setting");
+
+        // Assert
+        Assert.Equal("fallback-value", value);
+        Assert.Equal(1, missing.Calls);
+        Assert.Equal(1, transient.Calls);
+        Assert.Equal(1, fallback.Calls);
+    }
+
+    /// <summary>
+    /// Verifies required transient failures fail fast instead of falling back.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetConfigValueAsync_ThrowsVaultOperationException_WhenRequiredProviderFailsTransiently()
+    {
+        // Arrange
+        var required = new TestConfigProvider("required", exception: new TimeoutException("timeout"));
+        var fallback = new TestConfigProvider("fallback", "fallback-value");
+        var source = CreateSource([
+            Register(required, priority: 1, required: true),
+            Register(fallback, priority: 2)]);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<VaultOperationException>(() => source.GetConfigValueAsync("setting"));
+        Assert.Contains("Failed to retrieve configuration key", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(1, required.Calls);
+        Assert.Equal(0, fallback.Calls);
+    }
+
+    /// <summary>
+    /// Verifies fatal provider configuration failures fail fast.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetConfigValueAsync_ThrowsVaultOperationException_WhenProviderHasFatalConfigurationError()
+    {
+        // Arrange
+        var fatal = new TestConfigProvider("fatal", exception: new InvalidOperationException("missing required configuration"));
+        var fallback = new TestConfigProvider("fallback", "fallback-value");
+        var source = CreateSource([
+            Register(fatal, priority: 1),
+            Register(fallback, priority: 2)]);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<VaultOperationException>(() => source.GetConfigValueAsync("setting"));
+        Assert.Equal(1, fatal.Calls);
+        Assert.Equal(0, fallback.Calls);
+    }
+
+    /// <summary>
+    /// Verifies try-get returns null when all providers miss.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task TryGetConfigValueAsync_ReturnsNull_WhenAllProvidersMiss()
+    {
+        // Arrange
+        var source = CreateSource([
+            Register(new TestConfigProvider("missing", value: null), priority: 1)]);
+
+        // Act
+        var value = await source.TryGetConfigValueAsync("setting");
+
+        // Assert
+        Assert.Null(value);
+    }
+
+    /// <summary>
+    /// Verifies typed and <see cref="IConfigProvider"/> members delegate through composite lookups.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task TypedAndIConfigProviderMembers_DelegateToCompositeLookups()
+    {
+        // Arrange
+        var source = CreateSource([Register(new TestConfigProvider("provider", "42"))]);
+        var provider = (IConfigProvider)source;
+
+        // Act & Assert
+        Assert.Equal(42, await source.GetConfigValueAsync<int>("answer"));
+        Assert.Equal(42, await source.TryGetConfigValueAsync("answer", 0));
+        Assert.Equal("42", await provider.GetValueAsync("answer"));
+        Assert.Equal("42", await provider.TryGetValueAsync("answer"));
+        Assert.Equal(42, await provider.GetValueAsync<int>("answer"));
+        Assert.Equal(42, await provider.GetValueAsync("answer", 0));
+    }
+
+    private static CompositeConfigSource CreateSource(IEnumerable<RegisteredConfigSourceProvider> providers)
+    {
+        var resilience = new ResiliencePipelineFactory(
+            new VaultResilienceOptions { RetryEnabled = false, CircuitBreakerEnabled = false },
+            NullLogger<ResiliencePipelineFactory>.Instance);
+
+        return new CompositeConfigSource(providers, resilience, NullLogger<CompositeConfigSource>.Instance);
+    }
+
+    private static RegisteredConfigSourceProvider Register(
+        TestConfigProvider provider,
+        int priority = 0,
+        bool enabled = true,
+        bool required = false)
+    {
+        return new RegisteredConfigSourceProvider(
+            provider,
+            new ProviderRegistration
+            {
+                Name = provider.ProviderName,
+                IsEnabled = enabled,
+                IsRequired = required,
+                Priority = priority,
+            });
+    }
+
+    private sealed class TestConfigProvider(
+        string providerName,
+        string? value = null,
+        bool isAvailable = true,
+        Exception? exception = null) : IConfigSourceProvider
+    {
+        public string ProviderName { get; } = providerName;
+
+        public bool IsAvailable { get; } = isAvailable;
+
+        public int Calls { get; private set; }
+
+        public Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(IsAvailable);
+        }
+
+        public Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<T> GetConfigValueAsync<T>(string key, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
+        {
+            Calls++;
+            return exception is null ? Task.FromResult(value) : Task.FromException<string?>(exception);
+        }
+
+        public Task<T> TryGetConfigValueAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/ConfigurationProviderTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/ConfigurationProviderTests.cs
@@ -1,0 +1,198 @@
+using HoneyDrunk.Vault.Exceptions;
+using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Providers.Configuration.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace HoneyDrunk.Vault.Tests.Services;
+
+/// <summary>
+/// Tests for configuration-backed secret and configuration providers.
+/// </summary>
+public sealed class ConfigurationProviderTests
+{
+    /// <summary>
+    /// Verifies configuration source returns configured string values.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ConfigurationConfigSource_GetConfigValueAsync_ReturnsValue_WhenPresent()
+    {
+        // Arrange
+        var source = CreateConfigSource(new Dictionary<string, string?> { ["Feature:Name"] = "vault" });
+
+        // Act
+        var value = await source.GetConfigValueAsync("Feature:Name");
+
+        // Assert
+        Assert.Equal("vault", value);
+    }
+
+    /// <summary>
+    /// Verifies missing configuration source keys throw not-found exceptions.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ConfigurationConfigSource_GetConfigValueAsync_Throws_WhenMissing()
+    {
+        // Arrange
+        var source = CreateConfigSource([]);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConfigurationNotFoundException>(() => source.GetConfigValueAsync("missing"));
+    }
+
+    /// <summary>
+    /// Verifies try-get returns null for missing string keys.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ConfigurationConfigSource_TryGetConfigValueAsync_ReturnsNull_WhenMissing()
+    {
+        // Arrange
+        var source = CreateConfigSource([]);
+
+        // Act
+        var value = await source.TryGetConfigValueAsync("missing");
+
+        // Assert
+        Assert.Null(value);
+    }
+
+    /// <summary>
+    /// Verifies typed configuration values are read through Microsoft configuration binding.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ConfigurationConfigSource_GetConfigValueAsync_Typed_ReturnsValue()
+    {
+        // Arrange
+        var source = CreateConfigSource(new Dictionary<string, string?> { ["Retries"] = "5" });
+
+        // Act
+        var value = await source.GetConfigValueAsync<int>("Retries");
+
+        // Assert
+        Assert.Equal(5, value);
+    }
+
+    /// <summary>
+    /// Verifies typed try-get returns the default value when conversion fails.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ConfigurationConfigSource_TryGetConfigValueAsync_Typed_ReturnsDefault_WhenConversionFails()
+    {
+        // Arrange
+        var source = CreateConfigSource(new Dictionary<string, string?> { ["Retries"] = "not-an-int" });
+
+        // Act
+        var value = await source.TryGetConfigValueAsync("Retries", 3);
+
+        // Assert
+        Assert.Equal(3, value);
+    }
+
+    /// <summary>
+    /// Verifies configuration secret store reads secrets under the Secrets section.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ConfigurationSecretStore_GetSecretAsync_ReturnsSecret_WhenPresent()
+    {
+        // Arrange
+        var store = CreateSecretStore(new Dictionary<string, string?> { ["Secrets:ApiKey"] = "secret-value" });
+
+        // Act
+        var secret = await store.GetSecretAsync(new SecretIdentifier("ApiKey", "v1"));
+
+        // Assert
+        Assert.Equal("ApiKey", secret.Identifier.Name);
+        Assert.Equal("secret-value", secret.Value);
+        Assert.Equal("v1", secret.Version);
+    }
+
+    /// <summary>
+    /// Verifies missing configuration secrets throw not-found exceptions.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ConfigurationSecretStore_GetSecretAsync_Throws_WhenMissing()
+    {
+        // Arrange
+        var store = CreateSecretStore([]);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<SecretNotFoundException>(() => store.GetSecretAsync(new SecretIdentifier("missing")));
+    }
+
+    /// <summary>
+    /// Verifies try-get wraps missing secrets as failed vault results.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ConfigurationSecretStore_TryGetSecretAsync_ReturnsFailure_WhenMissing()
+    {
+        // Arrange
+        var store = CreateSecretStore([]);
+
+        // Act
+        var result = await store.TryGetSecretAsync(new SecretIdentifier("missing"));
+
+        // Assert
+        Assert.False(result.IsSuccess);
+    }
+
+    /// <summary>
+    /// Verifies version listing reports the single configuration-backed latest version.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ConfigurationSecretStore_ListSecretVersionsAsync_ReturnsLatest_WhenPresent()
+    {
+        // Arrange
+        var store = CreateSecretStore(new Dictionary<string, string?> { ["Secrets:ApiKey"] = "secret-value" });
+
+        // Act
+        var versions = await store.ListSecretVersionsAsync("ApiKey");
+
+        // Assert
+        var version = Assert.Single(versions);
+        Assert.Equal("latest", version.Version);
+    }
+
+    /// <summary>
+    /// Verifies version listing validates the secret name.
+    /// </summary>
+    /// <param name="secretName">The invalid secret name to test.</param>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ConfigurationSecretStore_ListSecretVersionsAsync_Throws_WhenNameInvalid(string? secretName)
+    {
+        // Arrange
+        var store = CreateSecretStore([]);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => store.ListSecretVersionsAsync(secretName!));
+    }
+
+    private static ConfigurationConfigSource CreateConfigSource(Dictionary<string, string?> values)
+    {
+        return new ConfigurationConfigSource(CreateConfiguration(values), NullLogger<ConfigurationConfigSource>.Instance);
+    }
+
+    private static ConfigurationSecretStore CreateSecretStore(Dictionary<string, string?> values)
+    {
+        return new ConfigurationSecretStore(CreateConfiguration(values), NullLogger<ConfigurationSecretStore>.Instance);
+    }
+
+    private static IConfiguration CreateConfiguration(Dictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/FileConfigSourceTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/FileConfigSourceTests.cs
@@ -1,0 +1,187 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Exceptions;
+using HoneyDrunk.Vault.Providers.File.Configuration;
+using HoneyDrunk.Vault.Providers.File.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace HoneyDrunk.Vault.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="FileConfigSource"/>.
+/// </summary>
+public sealed class FileConfigSourceTests : IDisposable
+{
+    private readonly string _tempFilePath;
+    private FileConfigSource? _source;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileConfigSourceTests"/> class.
+    /// </summary>
+    public FileConfigSourceTests()
+    {
+        _tempFilePath = Path.Combine(Path.GetTempPath(), $"test-config-{Guid.NewGuid():N}.json");
+    }
+
+    /// <summary>
+    /// Verifies missing config files are created when configured.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Constructor_CreatesEmptyFile_WhenCreateIfNotExistsEnabled()
+    {
+        // Act
+        _source = CreateSource(createIfNotExists: true);
+
+        // Assert
+        Assert.True(File.Exists(_tempFilePath));
+        Assert.Equal("{}", await File.ReadAllTextAsync(_tempFilePath));
+    }
+
+    /// <summary>
+    /// Verifies existing string values are loaded from the JSON config file.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetConfigValueAsync_ReturnsValue_WhenKeyExists()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(_tempFilePath, "{\"Feature:Enabled\":\"true\",\"Timeout\":\"30\"}");
+        _source = CreateSource();
+
+        // Act
+        var value = await _source.GetConfigValueAsync("Feature:Enabled");
+
+        // Assert
+        Assert.Equal("true", value);
+    }
+
+    /// <summary>
+    /// Verifies missing string values throw the expected not-found exception.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetConfigValueAsync_ThrowsConfigurationNotFoundException_WhenKeyIsMissing()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(_tempFilePath, "{}");
+        _source = CreateSource();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConfigurationNotFoundException>(() => _source.GetConfigValueAsync("missing"));
+    }
+
+    /// <summary>
+    /// Verifies missing values return null through the try-get path.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task TryGetConfigValueAsync_ReturnsNull_WhenKeyIsMissing()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(_tempFilePath, "{}");
+        _source = CreateSource();
+
+        // Act
+        var value = await _source.TryGetConfigValueAsync("missing");
+
+        // Assert
+        Assert.Null(value);
+    }
+
+    /// <summary>
+    /// Verifies typed values are converted from file strings.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetConfigValueAsync_Typed_ReturnsConvertedValue()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(_tempFilePath, "{\"Timeout\":\"30\"}");
+        _source = CreateSource();
+
+        // Act
+        var value = await _source.GetConfigValueAsync<int>("Timeout");
+
+        // Assert
+        Assert.Equal(30, value);
+    }
+
+    /// <summary>
+    /// Verifies typed try-get returns the default value when conversion fails.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task TryGetConfigValueAsync_Typed_ReturnsDefault_WhenConversionFails()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(_tempFilePath, "{\"Timeout\":\"not-an-int\"}");
+        _source = CreateSource();
+
+        // Act
+        var value = await _source.TryGetConfigValueAsync("Timeout", 10);
+
+        // Assert
+        Assert.Equal(10, value);
+    }
+
+    /// <summary>
+    /// Verifies <see cref="IConfigProvider"/> members delegate to the config-source behavior.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task IConfigProviderMembers_DelegateToConfigSourceBehavior()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(_tempFilePath, "{\"Name\":\"vault\",\"Retries\":\"4\"}");
+        _source = CreateSource();
+
+        // Act & Assert
+        var provider = (IConfigProvider)_source;
+        Assert.Equal("vault", await provider.GetValueAsync("Name"));
+        Assert.Equal("vault", await provider.TryGetValueAsync("Name"));
+        Assert.Equal(4, await provider.GetValueAsync<int>("Retries"));
+        Assert.Equal(4, await provider.GetValueAsync("Retries", 1));
+    }
+
+    /// <summary>
+    /// Verifies invalid JSON is swallowed and leaves the source empty.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task Constructor_LeavesSourceEmpty_WhenJsonIsInvalid()
+    {
+        // Arrange
+        await File.WriteAllTextAsync(_tempFilePath, "{ invalid json");
+
+        // Act
+        _source = CreateSource();
+
+        // Assert
+        await Assert.ThrowsAsync<ConfigurationNotFoundException>(() => _source.GetConfigValueAsync("any"));
+    }
+
+    /// <summary>
+    /// Disposes of test resources.
+    /// </summary>
+    public void Dispose()
+    {
+        _source?.Dispose();
+        if (File.Exists(_tempFilePath))
+        {
+            File.Delete(_tempFilePath);
+        }
+    }
+
+    private FileConfigSource CreateSource(bool createIfNotExists = false)
+    {
+        var options = Options.Create(new FileVaultOptions
+        {
+            ConfigFilePath = _tempFilePath,
+            CreateIfNotExists = createIfNotExists,
+            WatchForChanges = false,
+        });
+
+        return new FileConfigSource(options, NullLogger<FileConfigSource>.Instance);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/FileConfigSourceTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/FileConfigSourceTests.cs
@@ -20,7 +20,8 @@ public sealed class FileConfigSourceTests : IDisposable
     /// </summary>
     public FileConfigSourceTests()
     {
-        _tempFilePath = Path.Combine(Path.GetTempPath(), $"test-config-{Guid.NewGuid():N}.json");
+        _tempFilePath = Path.GetTempFileName();
+        File.Delete(_tempFilePath);
     }
 
     /// <summary>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Telemetry/VaultTelemetryBehaviorTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Telemetry/VaultTelemetryBehaviorTests.cs
@@ -1,0 +1,114 @@
+using HoneyDrunk.Vault.Telemetry;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
+
+namespace HoneyDrunk.Vault.Tests.Telemetry;
+
+/// <summary>
+/// Behavioral tests for <see cref="VaultTelemetry"/> operation execution.
+/// </summary>
+public sealed class VaultTelemetryBehaviorTests : IDisposable
+{
+    private readonly ActivityListener _listener;
+    private readonly List<Activity> _stoppedActivities = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VaultTelemetryBehaviorTests"/> class.
+    /// </summary>
+    public VaultTelemetryBehaviorTests()
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == VaultTelemetry.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = _stoppedActivities.Add,
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    /// <summary>
+    /// Verifies successful operations return their result and tag the activity with provider/key metadata.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExecuteWithTelemetryAsync_ReturnsResultAndTagsActivity_WhenOperationSucceeds()
+    {
+        // Arrange
+        var telemetry = new VaultTelemetry(NullLogger<VaultTelemetry>.Instance);
+
+        // Act
+        var result = await telemetry.ExecuteWithTelemetryAsync(
+            "get_secret",
+            "in-memory",
+            "api-key",
+            static _ => Task.FromResult("secret-value"));
+
+        // Assert
+        Assert.Equal("secret-value", result);
+        var activity = Assert.Single(_stoppedActivities);
+        Assert.Equal("vault.get_secret", activity.OperationName);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
+        Assert.Equal("in-memory", GetTag(activity, "vault.provider"));
+        Assert.Equal("api-key", GetTag(activity, "vault.key"));
+        Assert.Equal("success", GetTag(activity, "vault.result"));
+        Assert.Contains(GetTag(activity, "vault.cache"), new[] { "hit", "miss" });
+        Assert.DoesNotContain("secret-value", activity.Tags.Select(t => t.Value), StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies failed operations tag the activity as an error and rethrow the original exception.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ExecuteWithTelemetryAsync_TagsActivityAndRethrows_WhenOperationFails()
+    {
+        // Arrange
+        var telemetry = new VaultTelemetry(NullLogger<VaultTelemetry>.Instance);
+        var expected = new InvalidOperationException("boom");
+
+        // Act
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            telemetry.ExecuteWithTelemetryAsync<string>(
+                "get_secret",
+                "file",
+                "api-key",
+                _ => Task.FromException<string>(expected)));
+
+        // Assert
+        Assert.Same(expected, actual);
+        var activity = Assert.Single(_stoppedActivities);
+        Assert.Equal("error", GetTag(activity, "vault.result"));
+        Assert.Equal(ActivityStatusCode.Error, activity.Status);
+        Assert.Equal("boom", activity.StatusDescription);
+    }
+
+    /// <summary>
+    /// Verifies cache telemetry helper methods can be invoked without an active activity.
+    /// </summary>
+    [Fact]
+    public void CacheTelemetryHelpers_CompleteWithoutActivity()
+    {
+        // Arrange
+        var telemetry = new VaultTelemetry(NullLogger<VaultTelemetry>.Instance);
+
+        // Act
+        telemetry.RecordCacheHit("api-key");
+        telemetry.RecordCacheMiss("api-key");
+
+        // Assert
+        Assert.Empty(_stoppedActivities);
+    }
+
+    /// <summary>
+    /// Disposes of resources.
+    /// </summary>
+    public void Dispose()
+    {
+        _listener.Dispose();
+    }
+
+    private static string? GetTag(Activity activity, string key)
+    {
+        return activity.Tags.SingleOrDefault(tag => tag.Key == key).Value;
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Telemetry/VaultTelemetryBehaviorTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Telemetry/VaultTelemetryBehaviorTests.cs
@@ -52,7 +52,10 @@ public sealed class VaultTelemetryBehaviorTests : IDisposable
         Assert.Equal("api-key", GetTag(activity, "vault.key"));
         Assert.Equal("success", GetTag(activity, "vault.result"));
         Assert.Contains(GetTag(activity, "vault.cache"), new[] { "hit", "miss" });
-        Assert.DoesNotContain("secret-value", activity.Tags.Select(t => t.Value), StringComparer.Ordinal);
+        foreach (var tagValue in activity.Tags.Select(tag => tag.Value).Where(value => value is not null))
+        {
+            Assert.DoesNotContain("secret-value", tagValue, StringComparison.Ordinal);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Backfills Vault unit coverage across health/readiness contributors, startup warmup/validation, file/configuration providers, composite config fallback behavior, and telemetry execution.
- Seeds `HoneyDrunk.Vault/.github/coverage-baseline.json` at the locally measured total line coverage.
- Splits PR validation from the default-branch coverage ratchet: PRs run read-only `pr-core`; pushes to `main` run the write-scoped ratchet workflow.
- Adds the repo-level Unreleased/Internal changelog note.

## Coverage
- Initial measured total line coverage: **49.5%** (`1287/2600` lines).
- Final measured total line coverage: **71.8%** (`1869/2600` lines) with `-assemblyfilters:+*;-*.Tests`.
- Final branch coverage: **61.6%**.

## Validation
- `dotnet test HoneyDrunk.Vault\HoneyDrunk.Vault.slnx --no-restore` — **246 passed**.
- `dotnet test HoneyDrunk.Vault\HoneyDrunk.Vault.slnx --no-restore --collect:"XPlat Code Coverage" --results-directory coverage-raw-final` + `reportgenerator -assemblyfilters:"+*;-*.Tests"` — **71.8%** total line coverage.
- `dotnet format HoneyDrunk.Vault\HoneyDrunk.Vault.slnx --verify-no-changes --no-restore` — passed.
- Workflow YAML parse — passed.
- `git diff --check` — passed.

Notes: local restore/test still emits existing `NU1900` warnings because the private Azure Artifacts vulnerability feed cannot be reached from this machine; tests and coverage complete successfully.

Fixes #30
