### PR TITLE
test: align Vault with ADR-0047 test stack

### DIFF
--- a/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Internal
+- Migrated Vault tests from Moq to NSubstitute, adopted HoneyDrunk.Standards.Tests 0.2.9, and refreshed HoneyDrunk.Standards to 0.2.9 across package projects for ADR-0047 testing alignment.
 - Backfilled Vault test coverage above the Grid PR coverage gate floor and seeded the coverage baseline ratchet artifact.
 
 ## [0.5.0] - 2026-05-18

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="AWSSDK.SecretsManager" Version="4.0.4.17" />
     <PackageReference Include="AWSSDK.SSO" Version="4.0.2.24" />
     <PackageReference Include="AWSSDK.SSOOIDC" Version="4.0.3.25" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/README.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/README.md
@@ -215,7 +215,7 @@ public class MyServiceTests
 }
 ```
 
-### Testing with Moq
+### Testing with NSubstitute
 
 ```csharp
 public class MyServiceTests
@@ -224,27 +224,25 @@ public class MyServiceTests
     public async Task MyMethod_WithDependency_CallsSecretStore()
     {
         // Arrange
-        var secretStoreMock = new Mock<ISecretStore>();
-        secretStoreMock
-            .Setup(s => s.GetSecretAsync(
-                It.IsAny<SecretIdentifier>(), 
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new SecretValue(
-                new SecretIdentifier("key"), 
-                "value", 
+        var secretStore = Substitute.For<ISecretStore>();
+        secretStore
+            .GetSecretAsync(
+                Arg.Any<SecretIdentifier>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new SecretValue(
+                new SecretIdentifier("key"),
+                "value",
                 "1"));
 
-        var service = new MyService(secretStoreMock.Object);
+        var service = new MyService(secretStore);
 
         // Act
         var result = await service.MyMethodAsync();
 
         // Assert
-        secretStoreMock.Verify(
-            s => s.GetSecretAsync(
-                It.IsAny<SecretIdentifier>(),
-                It.IsAny<CancellationToken>()),
-            Times.Once);
+        await secretStore.Received(1).GetSecretAsync(
+            Arg.Any<SecretIdentifier>(),
+            Arg.Any<CancellationToken>());
     }
 }
 ```

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
@@ -4,7 +4,7 @@ using HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.DependencyInjection;
-using Moq;
+using NSubstitute;
 
 namespace HoneyDrunk.Vault.Tests.Extensions;
 
@@ -26,15 +26,11 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         services.AddSingleton<IConfiguration>(configuration);
 
         var builder = CreateBuilder(services);
-        var mockCredential = new Mock<TokenCredential>();
-        mockCredential
-            .Setup(c => c.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()))
-            .Returns(new ValueTask<AccessToken>(new AccessToken("fake-token", DateTimeOffset.MaxValue)));
 
         var result = builder.AddAppConfiguration(o =>
         {
             o.Optional = true;
-            o.Credential = mockCredential.Object;
+            o.Credential = new StaticTokenCredential();
             o.StartupTimeout = TimeSpan.FromMilliseconds(1);
         });
 
@@ -79,8 +75,26 @@ public sealed class AppConfigurationBootstrapExtensionsTests
 
     private static IHoneyDrunkBuilder CreateBuilder(IServiceCollection services)
     {
-        var builderMock = new Mock<IHoneyDrunkBuilder>();
-        builderMock.SetupGet(static b => b.Services).Returns(services);
-        return builderMock.Object;
+        var builder = Substitute.For<IHoneyDrunkBuilder>();
+        builder.Services.Returns(services);
+        return builder;
+    }
+
+    private sealed class StaticTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            return CreateToken();
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            return new ValueTask<AccessToken>(CreateToken());
+        }
+
+        private static AccessToken CreateToken()
+        {
+            return new AccessToken("fake-token", DateTimeOffset.MaxValue);
+        }
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultHoneyDrunkBuilderExtensionsTests.cs
@@ -5,7 +5,7 @@ using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Moq;
+using NSubstitute;
 
 namespace HoneyDrunk.Vault.Tests.Extensions;
 
@@ -75,8 +75,8 @@ public sealed class AzureKeyVaultHoneyDrunkBuilderExtensionsTests
 
     private static IHoneyDrunkBuilder CreateBuilder(IServiceCollection services)
     {
-        var builderMock = new Mock<IHoneyDrunkBuilder>();
-        builderMock.SetupGet(static b => b.Services).Returns(services);
-        return builderMock.Object;
+        var builder = Substitute.For<IHoneyDrunkBuilder>();
+        builder.Services.Returns(services);
+        return builder;
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
@@ -11,23 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="HoneyDrunk.Kernel" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="HoneyDrunk.Standards.Tests" Version="0.2.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/CompositeSecretStoreTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/CompositeSecretStoreTests.cs
@@ -5,7 +5,7 @@ using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Resilience;
 using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 
 namespace HoneyDrunk.Vault.Tests.Services;
 
@@ -46,8 +46,8 @@ public sealed class CompositeSecretStoreTests
 
         var providers = new[]
         {
-            new RegisteredSecretProvider(lowPriorityProvider.Object, CreateRegistration("low", priority: 100)),
-            new RegisteredSecretProvider(highPriorityProvider.Object, CreateRegistration("high", priority: 1)),
+            new RegisteredSecretProvider(lowPriorityProvider, CreateRegistration("low", priority: 100)),
+            new RegisteredSecretProvider(highPriorityProvider, CreateRegistration("high", priority: 1)),
         };
 
         var store = CreateCompositeStore(providers);
@@ -58,8 +58,8 @@ public sealed class CompositeSecretStoreTests
         // Assert
         Assert.True(result.IsSuccess);
         Assert.Equal("secret-value-high", result.Value!.Value);
-        highPriorityProvider.Verify(p => p.FetchSecretAsync("test-secret", null, It.IsAny<CancellationToken>()), Times.Once);
-        lowPriorityProvider.Verify(p => p.FetchSecretAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        await highPriorityProvider.Received(1).FetchSecretAsync("test-secret", null, Arg.Any<CancellationToken>());
+        await lowPriorityProvider.DidNotReceive().FetchSecretAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     /// <summary>
@@ -75,8 +75,8 @@ public sealed class CompositeSecretStoreTests
 
         var providers = new[]
         {
-            new RegisteredSecretProvider(highPriorityProvider.Object, CreateRegistration("high", priority: 1)),
-            new RegisteredSecretProvider(lowPriorityProvider.Object, CreateRegistration("low", priority: 100)),
+            new RegisteredSecretProvider(highPriorityProvider, CreateRegistration("high", priority: 1)),
+            new RegisteredSecretProvider(lowPriorityProvider, CreateRegistration("low", priority: 100)),
         };
 
         var store = CreateCompositeStore(providers);
@@ -87,8 +87,8 @@ public sealed class CompositeSecretStoreTests
         // Assert
         Assert.True(result.IsSuccess);
         Assert.Equal("secret-value-low", result.Value!.Value);
-        highPriorityProvider.Verify(p => p.FetchSecretAsync("test-secret", null, It.IsAny<CancellationToken>()), Times.Once);
-        lowPriorityProvider.Verify(p => p.FetchSecretAsync("test-secret", null, It.IsAny<CancellationToken>()), Times.Once);
+        await highPriorityProvider.Received(1).FetchSecretAsync("test-secret", null, Arg.Any<CancellationToken>());
+        await lowPriorityProvider.Received(1).FetchSecretAsync("test-secret", null, Arg.Any<CancellationToken>());
     }
 
     /// <summary>
@@ -98,9 +98,9 @@ public sealed class CompositeSecretStoreTests
     public void Constructor_OrdersProvidersByPriority()
     {
         // Arrange
-        var provider1 = CreateMockProvider("provider-1").Object;
-        var provider2 = CreateMockProvider("provider-2").Object;
-        var provider3 = CreateMockProvider("provider-3").Object;
+        var provider1 = CreateMockProvider("provider-1");
+        var provider2 = CreateMockProvider("provider-2");
+        var provider3 = CreateMockProvider("provider-3");
 
         var providers = new[]
         {
@@ -132,8 +132,8 @@ public sealed class CompositeSecretStoreTests
 
         var providers = new[]
         {
-            new RegisteredSecretProvider(requiredProvider.Object, CreateRegistration("required", priority: 1, isRequired: true)),
-            new RegisteredSecretProvider(fallbackProvider.Object, CreateRegistration("fallback", priority: 100)),
+            new RegisteredSecretProvider(requiredProvider, CreateRegistration("required", priority: 1, isRequired: true)),
+            new RegisteredSecretProvider(fallbackProvider, CreateRegistration("fallback", priority: 100)),
         };
 
         var store = CreateCompositeStore(providers);
@@ -144,7 +144,7 @@ public sealed class CompositeSecretStoreTests
         // Assert - Should fail fast, not fall back
         Assert.False(result.IsSuccess);
         Assert.Contains("Required provider", result.ErrorMessage);
-        fallbackProvider.Verify(p => p.FetchSecretAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        await fallbackProvider.DidNotReceive().FetchSecretAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     /// <summary>
@@ -160,8 +160,8 @@ public sealed class CompositeSecretStoreTests
 
         var providers = new[]
         {
-            new RegisteredSecretProvider(optionalProvider.Object, CreateRegistration("optional", priority: 1, isRequired: false)),
-            new RegisteredSecretProvider(fallbackProvider.Object, CreateRegistration("fallback", priority: 100)),
+            new RegisteredSecretProvider(optionalProvider, CreateRegistration("optional", priority: 1, isRequired: false)),
+            new RegisteredSecretProvider(fallbackProvider, CreateRegistration("fallback", priority: 100)),
         };
 
         var store = CreateCompositeStore(providers);
@@ -187,8 +187,8 @@ public sealed class CompositeSecretStoreTests
 
         var providers = new[]
         {
-            new RegisteredSecretProvider(requiredProvider.Object, CreateRegistration("required", priority: 1, isRequired: true)),
-            new RegisteredSecretProvider(fallbackProvider.Object, CreateRegistration("fallback", priority: 100)),
+            new RegisteredSecretProvider(requiredProvider, CreateRegistration("required", priority: 1, isRequired: true)),
+            new RegisteredSecretProvider(fallbackProvider, CreateRegistration("fallback", priority: 100)),
         };
 
         var store = CreateCompositeStore(providers);
@@ -214,8 +214,8 @@ public sealed class CompositeSecretStoreTests
 
         var providers = new[]
         {
-            new RegisteredSecretProvider(fatalProvider.Object, CreateRegistration("fatal", priority: 1)),
-            new RegisteredSecretProvider(fallbackProvider.Object, CreateRegistration("fallback", priority: 100)),
+            new RegisteredSecretProvider(fatalProvider, CreateRegistration("fatal", priority: 1)),
+            new RegisteredSecretProvider(fallbackProvider, CreateRegistration("fallback", priority: 100)),
         };
 
         var store = CreateCompositeStore(providers);
@@ -226,7 +226,7 @@ public sealed class CompositeSecretStoreTests
         // Assert - Fatal config errors should fail fast
         Assert.False(result.IsSuccess);
         Assert.Contains("Fatal configuration error", result.ErrorMessage);
-        fallbackProvider.Verify(p => p.FetchSecretAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        await fallbackProvider.DidNotReceive().FetchSecretAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     /// <summary>
@@ -242,8 +242,8 @@ public sealed class CompositeSecretStoreTests
 
         var providers = new[]
         {
-            new RegisteredSecretProvider(provider1.Object, CreateRegistration("p1", priority: 1)),
-            new RegisteredSecretProvider(provider2.Object, CreateRegistration("p2", priority: 2)),
+            new RegisteredSecretProvider(provider1, CreateRegistration("p1", priority: 1)),
+            new RegisteredSecretProvider(provider2, CreateRegistration("p2", priority: 2)),
         };
 
         var store = CreateCompositeStore(providers);
@@ -267,7 +267,7 @@ public sealed class CompositeSecretStoreTests
         var provider = CreateMockProvider("provider", throwsNotFound: true);
         var providers = new[]
         {
-            new RegisteredSecretProvider(provider.Object, CreateRegistration("p", priority: 1)),
+            new RegisteredSecretProvider(provider, CreateRegistration("p", priority: 1)),
         };
 
         var store = CreateCompositeStore(providers);
@@ -288,7 +288,7 @@ public sealed class CompositeSecretStoreTests
         var provider = CreateMockProvider("provider", throwsFatalConfig: true);
         var providers = new[]
         {
-            new RegisteredSecretProvider(provider.Object, CreateRegistration("p", priority: 1)),
+            new RegisteredSecretProvider(provider, CreateRegistration("p", priority: 1)),
         };
 
         var store = CreateCompositeStore(providers);
@@ -310,7 +310,7 @@ public sealed class CompositeSecretStoreTests
         var provider = CreateMockProvider("provider", throwsTransient: true);
         var providers = new[]
         {
-            new RegisteredSecretProvider(provider.Object, CreateRegistration("p", priority: 1, isRequired: true)),
+            new RegisteredSecretProvider(provider, CreateRegistration("p", priority: 1, isRequired: true)),
         };
 
         var store = CreateCompositeStore(providers);
@@ -346,8 +346,8 @@ public sealed class CompositeSecretStoreTests
     public void Constructor_FiltersOutDisabledProviders()
     {
         // Arrange
-        var enabledProvider = CreateMockProvider("enabled").Object;
-        var disabledProvider = CreateMockProvider("disabled").Object;
+        var enabledProvider = CreateMockProvider("enabled");
+        var disabledProvider = CreateMockProvider("disabled");
 
         var providers = new[]
         {
@@ -370,8 +370,8 @@ public sealed class CompositeSecretStoreTests
     public void Constructor_FiltersOutUnavailableProviders()
     {
         // Arrange
-        var availableProvider = CreateMockProvider("available", isAvailable: true).Object;
-        var unavailableProvider = CreateMockProvider("unavailable", isAvailable: false).Object;
+        var availableProvider = CreateMockProvider("available", isAvailable: true);
+        var unavailableProvider = CreateMockProvider("unavailable", isAvailable: false);
 
         var providers = new[]
         {
@@ -402,7 +402,7 @@ public sealed class CompositeSecretStoreTests
         };
     }
 
-    private static Mock<ISecretProvider> CreateMockProvider(
+    private static ISecretProvider CreateMockProvider(
         string name,
         string? returnValue = null,
         bool throwsNotFound = false,
@@ -410,32 +410,32 @@ public sealed class CompositeSecretStoreTests
         bool throwsFatalConfig = false,
         bool isAvailable = true)
     {
-        var mock = new Mock<ISecretProvider>();
-        mock.Setup(p => p.ProviderName).Returns(name);
-        mock.Setup(p => p.IsAvailable).Returns(isAvailable);
+        var provider = Substitute.For<ISecretProvider>();
+        provider.ProviderName.Returns(name);
+        provider.IsAvailable.Returns(isAvailable);
 
         if (throwsNotFound)
         {
-            mock.Setup(p => p.FetchSecretAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new SecretNotFoundException("test-secret"));
+            provider.FetchSecretAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromException<SecretValue>(new SecretNotFoundException("test-secret")));
         }
         else if (throwsTransient)
         {
-            mock.Setup(p => p.FetchSecretAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new HttpRequestException("Transient network error"));
+            provider.FetchSecretAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromException<SecretValue>(new HttpRequestException("Transient network error")));
         }
         else if (throwsFatalConfig)
         {
-            mock.Setup(p => p.FetchSecretAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new InvalidOperationException("Missing required configuration"));
+            provider.FetchSecretAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromException<SecretValue>(new InvalidOperationException("Missing required configuration")));
         }
         else if (returnValue != null)
         {
-            mock.Setup(p => p.FetchSecretAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new SecretValue(new SecretIdentifier("test-secret"), returnValue, "v1"));
+            provider.FetchSecretAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+                .Returns(new SecretValue(new SecretIdentifier("test-secret"), returnValue, "v1"));
         }
 
-        return mock;
+        return provider;
     }
 
     private CompositeSecretStore CreateCompositeStore(IEnumerable<RegisteredSecretProvider> providers)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/TenantScopedSecretResolverTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/TenantScopedSecretResolverTests.cs
@@ -5,7 +5,7 @@ using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Providers.InMemory.Services;
 using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
 using System.Collections.Concurrent;
 
 namespace HoneyDrunk.Vault.Tests.Services;
@@ -116,17 +116,17 @@ public sealed class TenantScopedSecretResolverTests
     {
         // Arrange
         var tenantId = TenantId.NewId();
-        var store = new Mock<ISecretStore>();
-        store.Setup(s => s.GetSecretAsync(
-                It.Is<SecretIdentifier>(id => id.Name.StartsWith("tenant-", StringComparison.Ordinal)),
-                It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("provider offline"));
+        var store = Substitute.For<ISecretStore>();
+        store.GetSecretAsync(
+                Arg.Is<SecretIdentifier>(id => id.Name.StartsWith("tenant-", StringComparison.Ordinal)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SecretValue>(new InvalidOperationException("provider offline")));
 
-        var resolver = new TenantScopedSecretResolver(store.Object);
+        var resolver = new TenantScopedSecretResolver(store);
 
         // Act + Assert
         await Assert.ThrowsAsync<InvalidOperationException>(() => resolver.ResolveAsync(tenantId, "resend-api-key"));
-        store.Verify(s => s.GetSecretAsync(It.Is<SecretIdentifier>(id => id.Name == "resend-api-key"), It.IsAny<CancellationToken>()), Times.Never);
+        await store.DidNotReceive().GetSecretAsync(Arg.Is<SecretIdentifier>(id => id.Name == "resend-api-key"), Arg.Any<CancellationToken>());
     }
 
     /// <summary>
@@ -139,17 +139,17 @@ public sealed class TenantScopedSecretResolverTests
         // Arrange
         var tenantId = TenantId.NewId();
         var shared = new SecretValue(new SecretIdentifier("resend-api-key"), "shared-value", "v1");
-        var store = new Mock<ISecretStore>();
-        store.Setup(s => s.GetSecretAsync(
-                It.Is<SecretIdentifier>(id => id.Name.StartsWith("tenant-", StringComparison.Ordinal)),
-                It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new SecretNotFoundException("tenant-secret"));
-        store.Setup(s => s.GetSecretAsync(
-                It.Is<SecretIdentifier>(id => id.Name == "resend-api-key"),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(shared);
+        var store = Substitute.For<ISecretStore>();
+        store.GetSecretAsync(
+                Arg.Is<SecretIdentifier>(id => id.Name.StartsWith("tenant-", StringComparison.Ordinal)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SecretValue>(new SecretNotFoundException("tenant-secret")));
+        store.GetSecretAsync(
+                Arg.Is<SecretIdentifier>(id => id.Name == "resend-api-key"),
+                Arg.Any<CancellationToken>())
+            .Returns(shared);
 
-        var resolver = new TenantScopedSecretResolver(store.Object);
+        var resolver = new TenantScopedSecretResolver(store);
 
         // Act
         var result = await resolver.ResolveAsync(tenantId, "resend-api-key");
@@ -167,13 +167,13 @@ public sealed class TenantScopedSecretResolverTests
     {
         // Arrange
         var tenantId = TenantId.NewId();
-        var store = new Mock<ISecretStore>();
-        store.Setup(s => s.GetSecretAsync(
-                It.Is<SecretIdentifier>(id => id.Name.StartsWith("tenant-", StringComparison.Ordinal)),
-                It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("provider offline"));
+        var store = Substitute.For<ISecretStore>();
+        store.GetSecretAsync(
+                Arg.Is<SecretIdentifier>(id => id.Name.StartsWith("tenant-", StringComparison.Ordinal)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<SecretValue>(new InvalidOperationException("provider offline")));
 
-        var resolver = new TenantScopedSecretResolver(store.Object);
+        var resolver = new TenantScopedSecretResolver(store);
 
         // Act
         var result = await resolver.TryResolveAsync(tenantId, "resend-api-key");
@@ -181,6 +181,6 @@ public sealed class TenantScopedSecretResolverTests
         // Assert
         Assert.False(result.IsSuccess);
         Assert.Contains("provider offline", result.ErrorMessage, StringComparison.Ordinal);
-        store.Verify(s => s.TryGetSecretAsync(It.Is<SecretIdentifier>(id => id.Name == "resend-api-key"), It.IsAny<CancellationToken>()), Times.Never);
+        await store.DidNotReceive().TryGetSecretAsync(Arg.Is<SecretIdentifier>(id => id.Name == "resend-api-key"), Arg.Any<CancellationToken>());
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/VaultClientTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/VaultClientTests.cs
@@ -3,7 +3,8 @@ using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace HoneyDrunk.Vault.Tests.Services;
 
@@ -12,8 +13,8 @@ namespace HoneyDrunk.Vault.Tests.Services;
 /// </summary>
 public sealed class VaultClientTests
 {
-    private readonly Mock<ISecretStore> _mockSecretStore;
-    private readonly Mock<IConfigSource> _mockConfigSource;
+    private readonly ISecretStore _secretStore;
+    private readonly IConfigSource _configSource;
     private readonly VaultClient _vaultClient;
 
     /// <summary>
@@ -21,11 +22,11 @@ public sealed class VaultClientTests
     /// </summary>
     public VaultClientTests()
     {
-        _mockSecretStore = new Mock<ISecretStore>();
-        _mockConfigSource = new Mock<IConfigSource>();
+        _secretStore = Substitute.For<ISecretStore>();
+        _configSource = Substitute.For<IConfigSource>();
         _vaultClient = new VaultClient(
-            _mockSecretStore.Object,
-            _mockConfigSource.Object,
+            _secretStore,
+            _configSource,
             NullLogger<VaultClient>.Instance);
     }
 
@@ -39,16 +40,16 @@ public sealed class VaultClientTests
         // Arrange
         var identifier = new SecretIdentifier("test-secret");
         var expectedValue = new SecretValue(identifier, "secret-value", "v1");
-        _mockSecretStore
-            .Setup(s => s.GetSecretAsync(identifier, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expectedValue);
+        _secretStore
+            .GetSecretAsync(identifier, Arg.Any<CancellationToken>())
+            .Returns(expectedValue);
 
         // Act
         var result = await _vaultClient.GetSecretAsync(identifier);
 
         // Assert
         Assert.Equal(expectedValue, result);
-        _mockSecretStore.Verify(s => s.GetSecretAsync(identifier, It.IsAny<CancellationToken>()), Times.Once);
+        await _secretStore.Received(1).GetSecretAsync(identifier, Arg.Any<CancellationToken>());
     }
 
     /// <summary>
@@ -60,8 +61,8 @@ public sealed class VaultClientTests
     {
         // Arrange
         var identifier = new SecretIdentifier("missing-secret");
-        _mockSecretStore
-            .Setup(s => s.GetSecretAsync(identifier, It.IsAny<CancellationToken>()))
+        _secretStore
+            .GetSecretAsync(identifier, Arg.Any<CancellationToken>())
             .ThrowsAsync(new SecretNotFoundException("missing-secret"));
 
         // Act & Assert
@@ -78,8 +79,8 @@ public sealed class VaultClientTests
     {
         // Arrange
         var identifier = new SecretIdentifier("error-secret");
-        _mockSecretStore
-            .Setup(s => s.GetSecretAsync(identifier, It.IsAny<CancellationToken>()))
+        _secretStore
+            .GetSecretAsync(identifier, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Something went wrong"));
 
         // Act & Assert
@@ -99,9 +100,9 @@ public sealed class VaultClientTests
         // Arrange
         var identifier = new SecretIdentifier("test-secret");
         var expectedValue = new SecretValue(identifier, "secret-value", "v1");
-        _mockSecretStore
-            .Setup(s => s.TryGetSecretAsync(identifier, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(VaultResult.Success(expectedValue));
+        _secretStore
+            .TryGetSecretAsync(identifier, Arg.Any<CancellationToken>())
+            .Returns(VaultResult.Success(expectedValue));
 
         // Act
         var result = await _vaultClient.TryGetSecretAsync(identifier);
@@ -120,9 +121,9 @@ public sealed class VaultClientTests
     {
         // Arrange
         var identifier = new SecretIdentifier("missing-secret");
-        _mockSecretStore
-            .Setup(s => s.TryGetSecretAsync(identifier, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(VaultResult.Failure<SecretValue>("Not found"));
+        _secretStore
+            .TryGetSecretAsync(identifier, Arg.Any<CancellationToken>())
+            .Returns(VaultResult.Failure<SecretValue>("Not found"));
 
         // Act
         var result = await _vaultClient.TryGetSecretAsync(identifier);
@@ -141,8 +142,8 @@ public sealed class VaultClientTests
     {
         // Arrange
         var identifier = new SecretIdentifier("error-secret");
-        _mockSecretStore
-            .Setup(s => s.TryGetSecretAsync(identifier, It.IsAny<CancellationToken>()))
+        _secretStore
+            .TryGetSecretAsync(identifier, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Error"));
 
         // Act
@@ -163,9 +164,9 @@ public sealed class VaultClientTests
         // Arrange
         const string key = "config-key";
         const string expectedValue = "config-value";
-        _mockConfigSource
-            .Setup(s => s.GetConfigValueAsync(key, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expectedValue);
+        _configSource
+            .GetConfigValueAsync(key, Arg.Any<CancellationToken>())
+            .Returns(expectedValue);
 
         // Act
         var result = await _vaultClient.GetConfigValueAsync(key);
@@ -183,8 +184,8 @@ public sealed class VaultClientTests
     {
         // Arrange
         const string key = "missing-key";
-        _mockConfigSource
-            .Setup(s => s.GetConfigValueAsync(key, It.IsAny<CancellationToken>()))
+        _configSource
+            .GetConfigValueAsync(key, Arg.Any<CancellationToken>())
             .ThrowsAsync(new ConfigurationNotFoundException(key));
 
         // Act & Assert
@@ -201,8 +202,8 @@ public sealed class VaultClientTests
     {
         // Arrange
         const string key = "error-key";
-        _mockConfigSource
-            .Setup(s => s.GetConfigValueAsync(key, It.IsAny<CancellationToken>()))
+        _configSource
+            .GetConfigValueAsync(key, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Error"));
 
         // Act & Assert
@@ -221,9 +222,9 @@ public sealed class VaultClientTests
         // Arrange
         const string key = "config-key";
         const string expectedValue = "config-value";
-        _mockConfigSource
-            .Setup(s => s.TryGetConfigValueAsync(key, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expectedValue);
+        _configSource
+            .TryGetConfigValueAsync(key, Arg.Any<CancellationToken>())
+            .Returns(expectedValue);
 
         // Act
         var result = await _vaultClient.TryGetConfigValueAsync(key);
@@ -241,8 +242,8 @@ public sealed class VaultClientTests
     {
         // Arrange
         const string key = "error-key";
-        _mockConfigSource
-            .Setup(s => s.TryGetConfigValueAsync(key, It.IsAny<CancellationToken>()))
+        _configSource
+            .TryGetConfigValueAsync(key, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Error"));
 
         // Act
@@ -261,9 +262,9 @@ public sealed class VaultClientTests
     {
         // Arrange
         const string key = "int-key";
-        _mockConfigSource
-            .Setup(s => s.GetConfigValueAsync<int>(key, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(42);
+        _configSource
+            .GetConfigValueAsync<int>(key, Arg.Any<CancellationToken>())
+            .Returns(42);
 
         // Act
         var result = await _vaultClient.GetConfigValueAsync<int>(key);
@@ -281,8 +282,8 @@ public sealed class VaultClientTests
     {
         // Arrange
         const string key = "error-key";
-        _mockConfigSource
-            .Setup(s => s.GetConfigValueAsync<int>(key, It.IsAny<CancellationToken>()))
+        _configSource
+            .GetConfigValueAsync<int>(key, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Conversion error"));
 
         // Act & Assert
@@ -300,9 +301,9 @@ public sealed class VaultClientTests
     {
         // Arrange
         const string key = "int-key";
-        _mockConfigSource
-            .Setup(s => s.TryGetConfigValueAsync(key, 0, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(42);
+        _configSource
+            .TryGetConfigValueAsync(key, 0, Arg.Any<CancellationToken>())
+            .Returns(42);
 
         // Act
         var result = await _vaultClient.TryGetConfigValueAsync(key, 0);
@@ -320,8 +321,8 @@ public sealed class VaultClientTests
     {
         // Arrange
         const string key = "error-key";
-        _mockConfigSource
-            .Setup(s => s.TryGetConfigValueAsync(key, 100, It.IsAny<CancellationToken>()))
+        _configSource
+            .TryGetConfigValueAsync(key, 100, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Error"));
 
         // Act
@@ -345,9 +346,9 @@ public sealed class VaultClientTests
             new("v1", DateTimeOffset.UtcNow.AddDays(-1)),
             new("v2", DateTimeOffset.UtcNow),
         };
-        _mockSecretStore
-            .Setup(s => s.ListSecretVersionsAsync(secretName, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(expectedVersions);
+        _secretStore
+            .ListSecretVersionsAsync(secretName, Arg.Any<CancellationToken>())
+            .Returns(expectedVersions);
 
         // Act
         var result = await _vaultClient.ListSecretVersionsAsync(secretName);
@@ -367,8 +368,8 @@ public sealed class VaultClientTests
     {
         // Arrange
         const string secretName = "error-secret";
-        _mockSecretStore
-            .Setup(s => s.ListSecretVersionsAsync(secretName, It.IsAny<CancellationToken>()))
+        _secretStore
+            .ListSecretVersionsAsync(secretName, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Error"));
 
         // Act & Assert
@@ -386,7 +387,7 @@ public sealed class VaultClientTests
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new VaultClient(
             null!,
-            _mockConfigSource.Object,
+            _configSource,
             NullLogger<VaultClient>.Instance));
     }
 
@@ -398,7 +399,7 @@ public sealed class VaultClientTests
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new VaultClient(
-            _mockSecretStore.Object,
+            _secretStore,
             null!,
             NullLogger<VaultClient>.Instance));
     }
@@ -411,8 +412,8 @@ public sealed class VaultClientTests
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() => new VaultClient(
-            _mockSecretStore.Object,
-            _mockConfigSource.Object,
+            _secretStore,
+            _configSource,
             null!));
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.5.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="HoneyDrunk.Kernel" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- migrate Vault tests and docs from Moq to NSubstitute
- adopt `HoneyDrunk.Standards.Tests` 0.2.9 in `HoneyDrunk.Vault.Tests` and remove direct xUnit/coverlet/Moq test-stack references
- refresh `HoneyDrunk.Standards` references from 0.2.7 to 0.2.9 across Vault package projects and document the alignment in changelogs

## Validation

- `git diff --check`
- `dotnet restore HoneyDrunk.Vault/HoneyDrunk.Vault.slnx --source https://api.nuget.org/v3/index.json`
- `dotnet test HoneyDrunk.Vault/HoneyDrunk.Vault.slnx -c Release --no-restore`
  - `HoneyDrunk.Vault.Tests`: 246 passed

## ADR / Issues

Contributes to HoneyDrunk.Architecture#188 and HoneyDrunk.Architecture#189.