### PR TITLE
ci(adr-0044): enable grid review requests

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,6 +2,7 @@ name: Grid Review Request
 
 on:
   pull_request:
+    branches: [ main ]
     types: [opened, synchronize, ready_for_review]
 
 permissions:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,23 @@
+name: Grid Review Request
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  request-grid-review:
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-review-request.yml@main
+    with:
+      openclaw-webhook-url: ${{ vars.OPENCLAW_GRID_REVIEW_WEBHOOK_URL || '' }}
+      review-config-path: .honeydrunk-review.yaml
+      upload-fallback-artifact: true
+      post-fallback-comment: false
+      artifact-name: grid-review-request
+    secrets:
+      openclaw-webhook-secret: ${{ secrets.OPENCLAW_GRID_REVIEW_WEBHOOK_SECRET }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      issues: write
       pull-requests: write
       security-events: write  # CodeQL SARIF upload
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main

--- a/.honeydrunk-review.yaml
+++ b/.honeydrunk-review.yaml
@@ -1,0 +1,8 @@
+enabled: true
+runner: openclaw-codex
+severity_floor: Suggest
+skip_paths:
+  - "**/*.Designer.cs"
+  - "**/*.g.cs"
+  - "**/generated/**"
+cost_cap_per_pr_usd: 0.00

--- a/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Internal
+- Enabled ADR-0044 OpenClaw/Codex Grid Review Runner request generation for Vault PRs.
 - Migrated Vault tests from Moq to NSubstitute, adopted HoneyDrunk.Standards.Tests 0.2.9, and refreshed HoneyDrunk.Standards to 0.2.9 across package projects for ADR-0047 testing alignment.
 - Backfilled Vault test coverage above the Grid PR coverage gate floor and seeded the coverage baseline ratchet artifact.
 


### PR DESCRIPTION
## Summary
- Enable ADR-0044 OpenClaw/Codex Grid Review Runner request generation for Vault PRs.
- Add .honeydrunk-review.yaml with advisory review enabled and standard generated-file skip paths.
- Add the pr-review.yml caller for job-review-request.yml, using the org-level OpenClaw webhook secret/variable.
- Grant issues: write to PR Core for managed labels/comments.
- Note the CI tooling change in the repository changelog.

Authorship: agent-codex
Packet: HoneyDrunk.Architecture#182 / generated/issue-packets/active/adr-0044-cloud-code-review/11-cross-repo-enable-review-ten-nodes.md
Out-of-band reason: N/A

## Verification
- python C:\Users\tatte\.openclaw\workspace\tmp-validate-yaml.py (temporary local YAML parse script)
- git diff --check

Size justification: N/A
