### PR TITLE
ci: use hive token for weekly dependency issues

### DIFF
--- a/.github/workflows/weekly-deps.yml
+++ b/.github/workflows/weekly-deps.yml
@@ -18,4 +18,4 @@ jobs:
       check-dotnet-deps: true
       create-update-prs: true
     secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}


### PR DESCRIPTION
## Summary

- switches weekly dependency issue maintenance from `GITHUB_TOKEN` to `HIVE_FIELD_MIRROR_TOKEN`
- keeps the already-merged `issues: write` permission required by `nightly-deps.yml`

## Why

The weekly dependency workflow creates/updates the `📦 Outdated Dependencies` issue. Issues created with `GITHUB_TOKEN` do not trigger downstream `issues:*` workflows, so Hive Field Mirror will not add them to the Hive project. Using `HIVE_FIELD_MIRROR_TOKEN` keeps dependency tracking issues on the normal Hive project mirroring path.

## Validation

- `git diff --check`
- same weekly-deps permission fix verified first in `HoneyDrunk.Transport`: https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/actions/runs/26415087947
- after merge, manually dispatch Vault `Weekly Dependencies` once to verify the dependency issue is created/updated and mirrored into Hive

Out-of-band reason: Follow-up fix to make weekly dependency tracking issues trigger Hive project mirroring; no generated packet exists for this operational correction.

Authorship: agent-codex
