### PR TITLE
chore(vault): sonar dedup + coverage backfill (0.6.0 → 0.7.0)

### DIFF
--- a/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/CHANGELOG.md
@@ -19,6 +19,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-27
+
+### Changed (breaking)
+
+- **`ISecretProvider` now extends `ISecretStore`** and exposes `FetchSecretAsync` / `TryFetchSecretAsync` / `ListVersionsAsync` as default interface methods that delegate to `SecretStoreFacade` against the inherited `ISecretStore` members. `ISecretStore.TryGetSecretAsync` is also a default interface method now. All in-repo provider stores (`InMemorySecretStore`, `FileSecretStore`, `AzureKeyVaultSecretStore`, `AwsSecretsManagerSecretStore`, `ConfigurationSecretStore`) drop the redundant per-provider overrides. **Migration:** callers that previously invoked these methods on the concrete provider class must now reach them through the `ISecretStore` / `ISecretProvider` interface (cast or DI).
+- **Package versions bumped** to `HoneyDrunk.Vault* 0.7.0` per pre-1.0 semver (`0.x.0 → 0.(x+1).0` for breaks).
+
+### Changed
+
+- New `DictionarySecretLookup` and `DictionaryConfigLookup` static helpers in `HoneyDrunk.Vault.Services` consolidate the dictionary-backed validate/lookup/throw pattern shared by the InMemory and File providers (both secret stores and config sources). Each provider's affected method collapses to a one-line delegation.
+- `AddVaultCore` now resolves `CompositeSecretStore` via a factory that calls `sp.GetService<VaultTelemetry>()` so the optional telemetry parameter binds to `null` when standalone provider extensions are used (without `HoneyDrunkBuilder.AddVault`). Also pre-registers a default `IOptions<VaultOptions>` so the caching factory does not blow up in that flow. Unblocks the standalone DI surface for `services.AddVaultInMemory()` etc.
+
+### Internal
+
+- Sonar duplication reduction (ADR-0011 D11). The "Duplicated Lines on New Code" findings on the nine secret-store / config-source files are addressed by the DIM promotion + helper extraction above.
+- 53 new tests across `VaultScope`, `InMemoryVaultOptions`, `AzureKeyVaultOptions`, the five provider `*ServiceCollectionExtensions`, `VaultEventGridServiceCollectionExtensions`, `AzureKeyVaultConfigSource`, `AwsSecretsManagerSecretStore`, and `VaultInvalidationFunctionHandler`. Total test count 248 → 301.
+- Test project now references `HoneyDrunk.Vault.Providers.Aws` directly so the AWS NSubstitute tests can wire `IAmazonSecretsManager`.
+
 ## [0.6.0] - 2026-05-26
 
 ### Changed (breaking)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-27
+
+### Changed
+- Version alignment with the HoneyDrunk.Vault 0.7.0 dedupe/coverage release (ADR-0011 D11).
+
+### Internal
+- First test coverage added for `VaultInvalidationFunctionHandler` (null-handler ctor guard, null-headers ctor guard, and a forwarding smoke test that proves the `IReadOnlyDictionary<string, string?>` headers bridge into the webhook handler).
+- First test coverage added for `VaultEventGridServiceCollectionExtensions.AddVaultEventGridInvalidation` (resolves both handlers + null-services guard).
+
 ## [0.6.0] - 2026-05-26
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
@@ -8,10 +8,10 @@
     <NoWarn>$(NoWarn);CA1873</NoWarn>
 
     <PackageId>HoneyDrunk.Vault.EventGrid</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Event Grid webhook helpers for HoneyDrunk.Vault cache invalidation.</Description>
-    <PackageReleaseNotes>v0.6.0: Version alignment with the Vault Sonar gate-cleanup (ADR-0011 D11) release. EventGrid webhook helper now uses headers.FirstOrDefault(...) with a case-insensitive predicate for header lookup (satisfies Sonar S3267 + S1751). See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.7.0: Version alignment with the HoneyDrunk.Vault 0.7.0 dedupe/coverage release (ADR-0011 D11). First test coverage added for VaultInvalidationFunctionHandler and the AddVaultEventGridInvalidation service-collection extension. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;eventgrid;azure;webhook;secrets;cache;rotation</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-27
+
+### Changed
+- Version alignment with the HoneyDrunk.Vault 0.7.0 dedupe/coverage release (ADR-0011 D11). No App Configuration-specific behavior change.
+
 ## [0.6.0] - 2026-05-26
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -8,10 +8,10 @@
     <NoWarn>$(NoWarn);CA1873</NoWarn>
 
     <PackageId>HoneyDrunk.Vault.Providers.AppConfiguration</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure App Configuration bootstrap extensions for HoneyDrunk.Vault using environment variable discovery.</Description>
-    <PackageReleaseNotes>v0.6.0: Version alignment with the Vault Sonar gate-cleanup (ADR-0011 D11) release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.7.0: Version alignment with the HoneyDrunk.Vault 0.7.0 dedupe/coverage release (ADR-0011 D11). See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;app-configuration;azure;feature-flags;configuration;bootstrap</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-27
+
+### Changed (breaking)
+- `AwsSecretsManagerSecretStore` now implements `ISecretProvider` directly (which extends `ISecretStore` per the 0.7.0 abstractions change). The `TryGetSecretAsync`, `FetchSecretAsync`, `TryFetchSecretAsync`, and `ListVersionsAsync` methods are now supplied as default interface methods on `ISecretStore` / `ISecretProvider` delegating to `SecretStoreFacade` — the redundant per-provider overrides have been removed. Callers that previously invoked these on the concrete store class must now reach them through the interface (cast or DI).
+
+### Internal
+- First test coverage added (`AwsSecretsManagerSecretStoreTests`). Uses NSubstitute against `IAmazonSecretsManager` and covers happy-path `GetSecretAsync`, `UseVersionId` toggle, `ResourceNotFoundException` → `SecretNotFoundException` wrapping, `AmazonSecretsManagerException` → `VaultOperationException` wrapping, secret-prefix application, `ListSecretVersionsAsync` pagination shape and 404 wrap, `CheckHealthAsync` success/failure, ctor null-options guard, and `Dispose` idempotence.
+
 ## [0.6.0] - 2026-05-26
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
@@ -9,10 +9,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Aws</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>AWS Secrets Manager provider for HoneyDrunk.Vault. Provides secure secret management using AWS Secrets Manager with support for IAM roles, access keys, and EC2 instance profiles.</Description>
-    <PackageReleaseNotes>v0.6.0: Version alignment with the Vault Sonar gate-cleanup (ADR-0011 D11) release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.7.0: AwsSecretsManagerSecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). First test coverage added (NSubstitute against IAmazonSecretsManager). See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;aws;secrets-manager;iam;access-keys;instance-profile;ec2;authentication</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/Services/AwsSecretsManagerSecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/Services/AwsSecretsManagerSecretStore.cs
@@ -5,7 +5,6 @@ using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Providers.Aws.Configuration;
-using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -14,7 +13,7 @@ namespace HoneyDrunk.Vault.Providers.Aws.Services;
 /// <summary>
 /// AWS Secrets Manager implementation of the secret store.
 /// </summary>
-public sealed class AwsSecretsManagerSecretStore : ISecretStore, ISecretProvider, IDisposable
+public sealed class AwsSecretsManagerSecretStore : ISecretProvider, IDisposable
 {
     private readonly AwsSecretsManagerOptions _options;
     private readonly IAmazonSecretsManager _client;
@@ -109,14 +108,6 @@ public sealed class AwsSecretsManagerSecretStore : ISecretStore, ISecretProvider
     }
 
     /// <inheritdoc/>
-    public async Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(identifier);
-
-        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, _logger, "AWS Secrets Manager", cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
     public async Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(secretName))
@@ -169,24 +160,6 @@ public sealed class AwsSecretsManagerSecretStore : ISecretStore, ISecretProvider
             _logger.LogError(ex, "Error listing versions for secret '{SecretId}' in AWS Secrets Manager", secretId);
             throw new VaultOperationException($"Failed to list versions for secret '{secretName}' from AWS Secrets Manager", ex);
         }
-    }
-
-    /// <inheritdoc/>
-    public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
-    {
-        return SecretStoreFacade.FetchSecretAsync(GetSecretAsync, key, version, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public async Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
-    {
-        return await SecretStoreFacade.TryFetchSecretAsync(TryGetSecretAsync, key, version, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
-    public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
-    {
-        return SecretStoreFacade.ListVersionsAsync(ListSecretVersionsAsync, key, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-27
+
+### Changed (breaking)
+- `AzureKeyVaultSecretStore` now implements `ISecretProvider` directly (which extends `ISecretStore` per the 0.7.0 abstractions change). The `TryGetSecretAsync`, `FetchSecretAsync`, `TryFetchSecretAsync`, and `ListVersionsAsync` methods are now supplied as default interface methods on `ISecretStore` / `ISecretProvider` delegating to `SecretStoreFacade` — the redundant per-provider overrides have been removed. Callers that previously invoked these on the concrete store class must now reach them through the interface (cast or DI).
+
+### Internal
+- First test coverage added (`AzureKeyVaultConfigSourceTests`). Uses NSubstitute against `ISecretStore` and covers happy-path `GetConfigValueAsync`, key normalisation (`:`/`__`/`.` → `-`), `SecretNotFoundException` → `ConfigurationNotFoundException` wrapping, null/whitespace key guard, `TryGetConfigValueAsync` success/failure/swallow-exception paths, and ctor null-arg guards.
+
 ## [0.6.0] - 2026-05-26
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -9,10 +9,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.AzureKeyVault</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Key Vault provider for HoneyDrunk.Vault. Provides enterprise-grade secret management using Azure Key Vault with support for Managed Identity and Service Principal authentication.</Description>
-    <PackageReleaseNotes>v0.6.0: Version alignment with the Vault Sonar gate-cleanup (ADR-0011 D11) release. AzureKeyVaultSecretStore health check now uses an explicit single-step enumerator instead of a single-iteration loop. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.7.0: AzureKeyVaultSecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). First test coverage added for AzureKeyVaultConfigSource. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;azure;key-vault;managed-identity;service-principal;authentication;enterprise</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Services/AzureKeyVaultSecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/Services/AzureKeyVaultSecretStore.cs
@@ -3,7 +3,6 @@ using Azure.Security.KeyVault.Secrets;
 using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
-using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
 
 namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Services;
@@ -18,7 +17,7 @@ namespace HoneyDrunk.Vault.Providers.AzureKeyVault.Services;
 /// <param name="logger">The logger.</param>
 public sealed class AzureKeyVaultSecretStore(
     SecretClient secretClient,
-    ILogger<AzureKeyVaultSecretStore> logger) : ISecretStore, ISecretProvider
+    ILogger<AzureKeyVaultSecretStore> logger) : ISecretProvider
 {
     private readonly SecretClient _secretClient = secretClient ?? throw new ArgumentNullException(nameof(secretClient));
     private readonly ILogger<AzureKeyVaultSecretStore> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -68,16 +67,6 @@ public sealed class AzureKeyVaultSecretStore(
     }
 
     /// <inheritdoc/>
-    public async Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(identifier);
-
-        _logger.LogDebug("Attempting to get secret '{SecretName}' from Azure Key Vault", identifier.Name);
-
-        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, _logger, "Azure Key Vault", cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
     public async Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(secretName))
@@ -120,24 +109,6 @@ public sealed class AzureKeyVaultSecretStore(
             _logger.LogError(ex, "Unexpected error listing versions for secret '{SecretName}' from Azure Key Vault", secretName);
             throw new VaultOperationException($"Failed to list versions for secret '{secretName}' from Azure Key Vault", ex);
         }
-    }
-
-    /// <inheritdoc/>
-    public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
-    {
-        return SecretStoreFacade.FetchSecretAsync(GetSecretAsync, key, version, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public async Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
-    {
-        return await SecretStoreFacade.TryFetchSecretAsync(TryGetSecretAsync, key, version, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
-    public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
-    {
-        return SecretStoreFacade.ListVersionsAsync(ListSecretVersionsAsync, key, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-27
+
+### Changed (breaking)
+- `ConfigurationSecretStore` drops the redundant `TryGetSecretAsync` override now that `ISecretStore` supplies it as a default interface method delegating to `SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, logger: null, …)`. The store remains `ISecretStore`-only (it is intentionally not part of the composite provider chain). Callers that previously invoked `TryGetSecretAsync` on the concrete class must now reach it through the `ISecretStore` interface.
+
 ## [0.6.0] - 2026-05-26
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
@@ -9,10 +9,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Configuration</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>.NET Configuration provider for HoneyDrunk.Vault. Enables reading secrets and configuration from standard .NET configuration sources (appsettings.json, environment variables, user secrets).</Description>
-    <PackageReleaseNotes>v0.6.0: Version alignment with the Vault Sonar gate-cleanup (ADR-0011 D11) release. ConfigurationConfigSource&lt;T&gt; presence detection switched to IConfigurationSection.Exists() + GetChildren().Any()/Value + section.Get&lt;T&gt;() so value-type defaults and complex/object sections both bind correctly. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.7.0: ConfigurationSecretStore drops the redundant TryGetSecretAsync override now that ISecretStore supplies it as a default interface method (breaking — see HoneyDrunk.Vault 0.7.0 notes). See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;configuration;secrets;appsettings;environment-variables;user-secrets;dotnet-config</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/Services/ConfigurationSecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/Services/ConfigurationSecretStore.cs
@@ -1,7 +1,6 @@
 using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
-using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -45,16 +44,6 @@ public sealed class ConfigurationSecretStore(
     }
 
     /// <inheritdoc/>
-    public async Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(identifier);
-
-        _logger.LogDebug("Attempting to get secret '{SecretName}' from configuration", identifier.Name);
-
-        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, _logger, "configuration", cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
     public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(secretName))
@@ -64,7 +53,6 @@ public sealed class ConfigurationSecretStore(
 
         _logger.LogDebug("Listing versions for secret '{SecretName}' from configuration", secretName);
 
-        // Configuration provider only supports a single version
         var key = BuildConfigurationKey(secretName);
         var value = _configuration[key];
 
@@ -74,6 +62,7 @@ public sealed class ConfigurationSecretStore(
             throw new SecretNotFoundException(secretName);
         }
 
+        // Configuration provider only supports a single version
         var versions = new List<SecretVersion>
         {
             new("latest", DateTimeOffset.UtcNow),

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-27
+
+### Changed (breaking)
+- `FileSecretStore` now implements `ISecretProvider` directly (which extends `ISecretStore` per the 0.7.0 abstractions change). The `TryGetSecretAsync`, `FetchSecretAsync`, `TryFetchSecretAsync`, and `ListVersionsAsync` methods are now supplied as default interface methods on `ISecretStore` / `ISecretProvider` delegating to `SecretStoreFacade` — the redundant per-provider overrides have been removed. Callers that previously invoked these on the concrete class must now reach them through the interface (cast or DI).
+
+### Changed
+- `FileSecretStore.GetSecretAsync` / `ListSecretVersionsAsync` and `FileConfigSource.GetConfigValueAsync` / `TryGetConfigValueAsync` now delegate to the new `DictionarySecretLookup` and `DictionaryConfigLookup` helpers in `HoneyDrunk.Vault`. Same observable behavior; same log shape; dramatically less duplication.
+
 ## [0.6.0] - 2026-05-26
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
@@ -9,10 +9,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.File</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>File-based secrets and configuration provider for HoneyDrunk.Vault. Ideal for local development and testing with support for file watching and optional encryption.</Description>
-    <PackageReleaseNotes>v0.6.0: Version alignment with the Vault Sonar gate-cleanup (ADR-0011 D11) release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.7.0: FileSecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). FileSecretStore and FileConfigSource now share new DictionarySecretLookup / DictionaryConfigLookup helpers in HoneyDrunk.Vault. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;configuration;file;development;testing;file-watcher</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileConfigSource.cs
@@ -66,6 +66,9 @@ public sealed class FileConfigSource : IConfigSource, IConfigProvider, IDisposab
     /// <inheritdoc/>
     public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
+        // FileConfigSource historically did not log on TryGet (only the throwing
+        // overload did). Pass logger: null so the helper stays silent here and
+        // preserves the legacy behavior.
         return DictionaryConfigLookup.TryGetConfigValueAsync(_configValues, key);
     }
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileConfigSource.cs
@@ -1,5 +1,4 @@
 using HoneyDrunk.Vault.Abstractions;
-using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Providers.File.Configuration;
 using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
@@ -14,6 +13,8 @@ namespace HoneyDrunk.Vault.Providers.File.Services;
 /// </summary>
 public sealed class FileConfigSource : IConfigSource, IConfigProvider, IDisposable
 {
+    private const string StoreName = "file store";
+
     private readonly FileVaultOptions _options;
     private readonly ILogger<FileConfigSource> _logger;
     private readonly ConcurrentDictionary<string, string> _configValues = new(StringComparer.OrdinalIgnoreCase);
@@ -59,27 +60,13 @@ public sealed class FileConfigSource : IConfigSource, IConfigProvider, IDisposab
     /// <inheritdoc/>
     public Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        ConfigSourceFacade.ValidateKey(key);
-
-        _logger.LogDebug("Getting configuration value for key '{Key}' from file store", key);
-
-        if (!_configValues.TryGetValue(key, out var value))
-        {
-            _logger.LogWarning("Configuration key '{Key}' not found in file store", key);
-            throw new ConfigurationNotFoundException(key);
-        }
-
-        _logger.LogDebug("Successfully retrieved configuration value for key '{Key}'", key);
-        return Task.FromResult(value);
+        return DictionaryConfigLookup.GetConfigValueAsync(_configValues, key, _logger, StoreName);
     }
 
     /// <inheritdoc/>
     public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        ConfigSourceFacade.ValidateKey(key);
-
-        _configValues.TryGetValue(key, out var value);
-        return Task.FromResult(value);
+        return DictionaryConfigLookup.TryGetConfigValueAsync(_configValues, key);
     }
 
     // IConfigProvider implementation — generic typed overloads come from the IConfigSource default interface methods.

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileSecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/Services/FileSecretStore.cs
@@ -1,5 +1,4 @@
 using HoneyDrunk.Vault.Abstractions;
-using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Providers.File.Configuration;
 using HoneyDrunk.Vault.Services;
@@ -13,8 +12,10 @@ namespace HoneyDrunk.Vault.Providers.File.Services;
 /// <summary>
 /// File-based implementation of the secret store for development and local testing.
 /// </summary>
-public sealed class FileSecretStore : ISecretStore, ISecretProvider, IDisposable
+public sealed class FileSecretStore : ISecretProvider, IDisposable
 {
+    private const string StoreName = "file store";
+
     private readonly FileVaultOptions _options;
     private readonly ILogger<FileSecretStore> _logger;
     private readonly ConcurrentDictionary<string, string> _secrets = new(StringComparer.OrdinalIgnoreCase);
@@ -64,68 +65,13 @@ public sealed class FileSecretStore : ISecretStore, ISecretProvider, IDisposable
     /// <inheritdoc/>
     public Task<SecretValue> GetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(identifier);
-
-        _logger.LogDebug("Getting secret '{SecretName}' from file store", identifier.Name);
-
-        if (!_secrets.TryGetValue(identifier.Name, out var value))
-        {
-            _logger.LogWarning("Secret '{SecretName}' not found in file store", identifier.Name);
-            throw new SecretNotFoundException(identifier.Name);
-        }
-
-        var secretValue = new SecretValue(identifier, value, "latest");
-        _logger.LogDebug("Successfully retrieved secret '{SecretName}' from file store", identifier.Name);
-
-        return Task.FromResult(secretValue);
-    }
-
-    /// <inheritdoc/>
-    public async Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(identifier);
-
-        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, _logger, "file store", cancellationToken).ConfigureAwait(false);
+        return DictionarySecretLookup.GetSecretAsync(_secrets, identifier, _logger, StoreName);
     }
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(secretName))
-        {
-            throw new ArgumentException("Secret name cannot be null or whitespace.", nameof(secretName));
-        }
-
-        if (!_secrets.ContainsKey(secretName))
-        {
-            throw new SecretNotFoundException(secretName);
-        }
-
-        // File store only supports single version
-        var versions = new List<SecretVersion>
-        {
-            new("latest", DateTimeOffset.UtcNow),
-        };
-
-        return Task.FromResult<IReadOnlyList<SecretVersion>>(versions);
-    }
-
-    /// <inheritdoc/>
-    public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
-    {
-        return SecretStoreFacade.FetchSecretAsync(GetSecretAsync, key, version, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public async Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
-    {
-        return await SecretStoreFacade.TryFetchSecretAsync(TryGetSecretAsync, key, version, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
-    public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
-    {
-        return SecretStoreFacade.ListVersionsAsync(ListSecretVersionsAsync, key, cancellationToken);
+        return DictionarySecretLookup.ListSecretVersionsAsync(_secrets, secretName, _logger, StoreName);
     }
 
     /// <inheritdoc/>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-27
+
+### Changed (breaking)
+- `InMemorySecretStore` now implements `ISecretProvider` directly (which extends `ISecretStore` per the 0.7.0 abstractions change). The `TryGetSecretAsync`, `FetchSecretAsync`, `TryFetchSecretAsync`, and `ListVersionsAsync` methods are now supplied as default interface methods on `ISecretStore` / `ISecretProvider` delegating to `SecretStoreFacade` — the redundant per-provider overrides have been removed. Callers that previously invoked these on the concrete class must now reach them through the interface (cast or DI).
+
+### Changed
+- `InMemorySecretStore.GetSecretAsync` / `ListSecretVersionsAsync` and `InMemoryConfigSource.GetConfigValueAsync` / `TryGetConfigValueAsync` now delegate to the new `DictionarySecretLookup` and `DictionaryConfigLookup` helpers in `HoneyDrunk.Vault`. Same observable behavior; same log shape; dramatically less duplication.
+
 ## [0.6.0] - 2026-05-26
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
@@ -9,10 +9,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.InMemory</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory provider for HoneyDrunk.Vault. Ideal for unit testing and integration testing with fast, thread-safe secret and configuration storage.</Description>
-    <PackageReleaseNotes>v0.6.0: Version alignment with the Vault Sonar gate-cleanup (ADR-0011 D11) release. InMemoryConfigSource declares only IConfigSourceProvider (which extends IConfigSource) for a cleaner inheritance list. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.7.0: InMemorySecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). InMemorySecretStore and InMemoryConfigSource now share new DictionarySecretLookup / DictionaryConfigLookup helpers in HoneyDrunk.Vault. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;testing;unit-testing;in-memory;mock;development</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemoryConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemoryConfigSource.cs
@@ -1,5 +1,4 @@
 using HoneyDrunk.Vault.Abstractions;
-using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
@@ -18,6 +17,8 @@ public sealed class InMemoryConfigSource(
     ConcurrentDictionary<string, string> configValues,
     ILogger<InMemoryConfigSource> logger) : IConfigSourceProvider
 {
+    private const string StoreName = "in-memory store";
+
     private readonly ConcurrentDictionary<string, string> _configValues = configValues ?? throw new ArgumentNullException(nameof(configValues));
     private readonly ILogger<InMemoryConfigSource> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -46,40 +47,13 @@ public sealed class InMemoryConfigSource(
     /// <inheritdoc/>
     public Task<string> GetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        ConfigSourceFacade.ValidateKey(key);
-
-        _logger.LogDebug("Getting configuration value for key '{Key}' from in-memory store", key);
-
-        if (!_configValues.TryGetValue(key, out var value))
-        {
-            _logger.LogWarning("Configuration key '{Key}' not found in in-memory store", key);
-            throw new ConfigurationNotFoundException(key);
-        }
-
-        _logger.LogDebug("Successfully retrieved configuration value for key '{Key}'", key);
-
-        return Task.FromResult(value);
+        return DictionaryConfigLookup.GetConfigValueAsync(_configValues, key, _logger, StoreName);
     }
 
     /// <inheritdoc/>
     public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        ConfigSourceFacade.ValidateKey(key);
-
-        _logger.LogDebug("Attempting to get configuration value for key '{Key}' from in-memory store", key);
-
-        _configValues.TryGetValue(key, out var value);
-
-        if (value != null)
-        {
-            _logger.LogDebug("Successfully retrieved configuration value for key '{Key}'", key);
-        }
-        else
-        {
-            _logger.LogDebug("Configuration value for key '{Key}' not found", key);
-        }
-
-        return Task.FromResult(value);
+        return DictionaryConfigLookup.TryGetConfigValueAsync(_configValues, key);
     }
 
     /// <summary>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemoryConfigSource.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemoryConfigSource.cs
@@ -53,7 +53,7 @@ public sealed class InMemoryConfigSource(
     /// <inheritdoc/>
     public Task<string?> TryGetConfigValueAsync(string key, CancellationToken cancellationToken = default)
     {
-        return DictionaryConfigLookup.TryGetConfigValueAsync(_configValues, key);
+        return DictionaryConfigLookup.TryGetConfigValueAsync(_configValues, key, _logger, StoreName);
     }
 
     /// <summary>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemorySecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/Services/InMemorySecretStore.cs
@@ -1,5 +1,4 @@
 using HoneyDrunk.Vault.Abstractions;
-using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Services;
 using Microsoft.Extensions.Logging;
@@ -17,8 +16,10 @@ namespace HoneyDrunk.Vault.Providers.InMemory.Services;
 /// <param name="logger">The logger.</param>
 public sealed class InMemorySecretStore(
     ConcurrentDictionary<string, string> secrets,
-    ILogger<InMemorySecretStore> logger) : ISecretStore, ISecretProvider
+    ILogger<InMemorySecretStore> logger) : ISecretProvider
 {
+    private const string StoreName = "in-memory store";
+
     private readonly ConcurrentDictionary<string, string> _secrets = secrets ?? throw new ArgumentNullException(nameof(secrets));
     private readonly ILogger<InMemorySecretStore> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -40,57 +41,13 @@ public sealed class InMemorySecretStore(
     /// <inheritdoc/>
     public Task<SecretValue> GetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(identifier);
-
-        _logger.LogDebug("Getting secret '{SecretName}' from in-memory store", identifier.Name);
-
-        if (!_secrets.TryGetValue(identifier.Name, out var value))
-        {
-            _logger.LogWarning("Secret '{SecretName}' not found in in-memory store", identifier.Name);
-            throw new SecretNotFoundException(identifier.Name);
-        }
-
-        var secretValue = new SecretValue(identifier, value, "latest");
-        _logger.LogDebug("Successfully retrieved secret '{SecretName}' from in-memory store", identifier.Name);
-
-        return Task.FromResult(secretValue);
-    }
-
-    /// <inheritdoc/>
-    public async Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(identifier);
-
-        _logger.LogDebug("Attempting to get secret '{SecretName}' from in-memory store", identifier.Name);
-
-        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, _logger, "in-memory store", cancellationToken).ConfigureAwait(false);
+        return DictionarySecretLookup.GetSecretAsync(_secrets, identifier, _logger, StoreName);
     }
 
     /// <inheritdoc/>
     public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(secretName))
-        {
-            throw new ArgumentException("Secret name cannot be null or whitespace.", nameof(secretName));
-        }
-
-        _logger.LogDebug("Listing versions for secret '{SecretName}' from in-memory store", secretName);
-
-        if (!_secrets.ContainsKey(secretName))
-        {
-            _logger.LogWarning("Secret '{SecretName}' not found in in-memory store", secretName);
-            throw new SecretNotFoundException(secretName);
-        }
-
-        // In-memory store only supports a single version
-        var versions = new List<SecretVersion>
-        {
-            new("latest", DateTimeOffset.UtcNow),
-        };
-
-        _logger.LogDebug("Listed {Count} version for secret '{SecretName}'", versions.Count, secretName);
-
-        return Task.FromResult<IReadOnlyList<SecretVersion>>(versions);
+        return DictionarySecretLookup.ListSecretVersionsAsync(_secrets, secretName, _logger, StoreName);
     }
 
     /// <summary>
@@ -139,24 +96,6 @@ public sealed class InMemorySecretStore(
     {
         _secrets.Clear();
         _logger.LogDebug("All secrets cleared from in-memory store");
-    }
-
-    /// <inheritdoc/>
-    public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
-    {
-        return SecretStoreFacade.FetchSecretAsync(GetSecretAsync, key, version, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public async Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
-    {
-        return await SecretStoreFacade.TryFetchSecretAsync(TryGetSecretAsync, key, version, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc/>
-    public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
-    {
-        return SecretStoreFacade.ListVersionsAsync(ListSecretVersionsAsync, key, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Configuration/AzureKeyVaultOptionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Configuration/AzureKeyVaultOptionsTests.cs
@@ -1,0 +1,47 @@
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Configuration;
+
+namespace HoneyDrunk.Vault.Tests.Configuration;
+
+/// <summary>
+/// Tests for <see cref="AzureKeyVaultOptions"/>.
+/// </summary>
+public sealed class AzureKeyVaultOptionsTests
+{
+    /// <summary>
+    /// Verifies the defaults — managed identity enabled, no URI/credentials populated.
+    /// </summary>
+    [Fact]
+    public void Defaults_MatchManagedIdentityShape()
+    {
+        var options = new AzureKeyVaultOptions();
+
+        Assert.Null(options.VaultUri);
+        Assert.True(options.UseManagedIdentity);
+        Assert.Null(options.TenantId);
+        Assert.Null(options.ClientId);
+        Assert.Null(options.ClientSecret);
+    }
+
+    /// <summary>
+    /// Verifies that properties are settable.
+    /// </summary>
+    [Fact]
+    public void Properties_AreSettable()
+    {
+        var uri = new Uri("https://kv.example.net/");
+        var options = new AzureKeyVaultOptions
+        {
+            VaultUri = uri,
+            UseManagedIdentity = false,
+            TenantId = "tenant",
+            ClientId = "client",
+            ClientSecret = "secret",
+        };
+
+        Assert.Equal(uri, options.VaultUri);
+        Assert.False(options.UseManagedIdentity);
+        Assert.Equal("tenant", options.TenantId);
+        Assert.Equal("client", options.ClientId);
+        Assert.Equal("secret", options.ClientSecret);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Configuration/InMemoryVaultOptionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Configuration/InMemoryVaultOptionsTests.cs
@@ -1,0 +1,66 @@
+using HoneyDrunk.Vault.Providers.InMemory.Configuration;
+
+namespace HoneyDrunk.Vault.Tests.Configuration;
+
+/// <summary>
+/// Tests for <see cref="InMemoryVaultOptions"/>.
+/// </summary>
+public sealed class InMemoryVaultOptionsTests
+{
+    /// <summary>
+    /// Verifies that the default options have empty case-insensitive dictionaries.
+    /// </summary>
+    [Fact]
+    public void Defaults_ExposeEmptyCaseInsensitiveDictionaries()
+    {
+        var options = new InMemoryVaultOptions();
+
+        Assert.Empty(options.Secrets);
+        Assert.Empty(options.ConfigurationValues);
+        options.Secrets["MIXED"] = "value";
+        Assert.True(options.Secrets.ContainsKey("mixed"));
+        options.ConfigurationValues["MIXED"] = "value";
+        Assert.True(options.ConfigurationValues.ContainsKey("mixed"));
+    }
+
+    /// <summary>
+    /// Verifies that AddSecret records the value and returns the options for chaining.
+    /// </summary>
+    [Fact]
+    public void AddSecret_RecordsValueAndReturnsSelf()
+    {
+        var options = new InMemoryVaultOptions();
+
+        var returned = options.AddSecret("api-key", "secret-value");
+
+        Assert.Same(options, returned);
+        Assert.Equal("secret-value", options.Secrets["api-key"]);
+    }
+
+    /// <summary>
+    /// Verifies that AddConfigValue records the value and returns the options for chaining.
+    /// </summary>
+    [Fact]
+    public void AddConfigValue_RecordsValueAndReturnsSelf()
+    {
+        var options = new InMemoryVaultOptions();
+
+        var returned = options.AddConfigValue("Database:Host", "localhost");
+
+        Assert.Same(options, returned);
+        Assert.Equal("localhost", options.ConfigurationValues["Database:Host"]);
+    }
+
+    /// <summary>
+    /// Verifies that AddSecret overwrites an existing value.
+    /// </summary>
+    [Fact]
+    public void AddSecret_OverwritesExistingValue()
+    {
+        var options = new InMemoryVaultOptions();
+        options.AddSecret("api-key", "first");
+        options.AddSecret("api-key", "second");
+
+        Assert.Equal("second", options.Secrets["api-key"]);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/EventGrid/VaultInvalidationFunctionHandlerTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/EventGrid/VaultInvalidationFunctionHandlerTests.cs
@@ -1,0 +1,63 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.EventGrid.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace HoneyDrunk.Vault.Tests.EventGrid;
+
+/// <summary>
+/// Tests for <see cref="VaultInvalidationFunctionHandler"/>. The handler is a thin
+/// wrapper around <see cref="VaultInvalidationWebhookHandler"/>; the tests focus on
+/// argument validation and request-shape forwarding.
+/// </summary>
+public sealed class VaultInvalidationFunctionHandlerTests
+{
+    /// <summary>
+    /// Verifies that the constructor rejects a null webhook handler.
+    /// </summary>
+    [Fact]
+    public void Constructor_ThrowsForNullHandler()
+    {
+        Assert.Throws<ArgumentNullException>(() => new VaultInvalidationFunctionHandler(null!));
+    }
+
+    /// <summary>
+    /// Verifies that HandleAsync rejects null headers.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleAsync_ThrowsForNullHeaders()
+    {
+        var handler = CreateHandler();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => handler.HandleAsync(headers: null!, body: "[]"));
+    }
+
+    /// <summary>
+    /// Verifies that HandleAsync forwards through to the webhook handler and returns
+    /// 401 Unauthorized when no shared-secret header is provided (proving the bridge works).
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task HandleAsync_ReturnsUnauthorized_WhenSharedSecretHeaderMissing()
+    {
+        var handler = CreateHandler();
+
+        var response = await handler.HandleAsync(
+            new Dictionary<string, string?>(),
+            body: "[]");
+
+        Assert.Equal(401, response.StatusCode);
+    }
+
+    private static VaultInvalidationFunctionHandler CreateHandler()
+    {
+        var webhookHandler = new VaultInvalidationWebhookHandler(
+            Substitute.For<ISecretStore>(),
+            Substitute.For<ISecretCacheInvalidator>(),
+            NullLogger<VaultInvalidationWebhookHandler>.Instance);
+
+        return new VaultInvalidationFunctionHandler(webhookHandler);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AwsSecretsManagerServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AwsSecretsManagerServiceCollectionExtensionsTests.cs
@@ -1,0 +1,91 @@
+using Amazon.SecretsManager;
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Providers.Aws.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="AwsSecretsManagerServiceCollectionExtensions"/>.
+/// </summary>
+public sealed class AwsSecretsManagerServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Verifies that the no-arg overload registers ISecretStore + ISecretProvider.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithAwsSecretsManager_NoArgs_RegistersStores()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<IAmazonSecretsManager>());
+
+        services.AddVaultWithAwsSecretsManager();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<ISecretStore>());
+        Assert.NotNull(provider.GetService<ISecretProvider>());
+    }
+
+    /// <summary>
+    /// Verifies that the configure overload threads options through.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithAwsSecretsManager_Configure_RegistersStores()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<IAmazonSecretsManager>());
+
+        services.AddVaultWithAwsSecretsManager(options =>
+        {
+            options.Region = "us-east-1";
+            options.SecretPrefix = "test/";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<ISecretStore>());
+    }
+
+    /// <summary>
+    /// Verifies that the client-factory overload registers a custom client.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithAwsSecretsManager_ClientFactory_RegistersStores()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var client = Substitute.For<IAmazonSecretsManager>();
+
+        services.AddVaultWithAwsSecretsManager(_ => client, options =>
+        {
+            options.Region = "us-east-1";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        Assert.Same(client, provider.GetRequiredService<IAmazonSecretsManager>());
+        Assert.NotNull(provider.GetService<ISecretStore>());
+    }
+
+    /// <summary>
+    /// Verifies that null arguments are rejected.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithAwsSecretsManager_ThrowsArgumentNullException_OnNullArguments()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            AwsSecretsManagerServiceCollectionExtensions.AddVaultWithAwsSecretsManager(
+                services: null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            services.AddVaultWithAwsSecretsManager(configure: null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            AwsSecretsManagerServiceCollectionExtensions.AddVaultWithAwsSecretsManager(
+                services: null!,
+                clientFactory: _ => Substitute.For<IAmazonSecretsManager>()));
+        Assert.Throws<ArgumentNullException>(() =>
+            services.AddVaultWithAwsSecretsManager(clientFactory: null!));
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AzureKeyVaultServiceCollectionExtensionsTests.cs
@@ -1,0 +1,81 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Configuration;
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="AzureKeyVaultServiceCollectionExtensions"/>.
+/// </summary>
+public sealed class AzureKeyVaultServiceCollectionExtensionsTests
+{
+    private static readonly Uri SampleVaultUri = new("https://kv.example.net/");
+
+    /// <summary>
+    /// Verifies that the configure overload registers ISecretStore and IConfigSource.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithAzureKeyVault_Configure_RegistersStoreAndConfigSource()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddVaultWithAzureKeyVault(options =>
+        {
+            options.VaultUri = SampleVaultUri;
+            options.UseManagedIdentity = true;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<ISecretStore>());
+        Assert.NotNull(provider.GetService<IConfigSource>());
+    }
+
+    /// <summary>
+    /// Verifies that the options-overload registers when given an explicit options instance.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithAzureKeyVault_WithOptionsInstance_Registers()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddVaultWithAzureKeyVault(new AzureKeyVaultOptions { VaultUri = SampleVaultUri });
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<ISecretStore>());
+    }
+
+    /// <summary>
+    /// Verifies that a missing VaultUri is rejected with ArgumentException.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithAzureKeyVault_ThrowsArgumentException_WhenVaultUriMissing()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentException>(() =>
+            services.AddVaultWithAzureKeyVault(new AzureKeyVaultOptions()));
+    }
+
+    /// <summary>
+    /// Verifies that null services/options/configure arguments are rejected.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithAzureKeyVault_ThrowsArgumentNullException_OnNullArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            AzureKeyVaultServiceCollectionExtensions.AddVaultWithAzureKeyVault(
+                services: null!,
+                configure: _ => { }));
+        Assert.Throws<ArgumentNullException>(() =>
+            new ServiceCollection().AddVaultWithAzureKeyVault(configure: null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            AzureKeyVaultServiceCollectionExtensions.AddVaultWithAzureKeyVault(
+                services: null!,
+                options: new AzureKeyVaultOptions { VaultUri = SampleVaultUri }));
+        Assert.Throws<ArgumentNullException>(() =>
+            new ServiceCollection().AddVaultWithAzureKeyVault(options: null!));
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/ConfigurationServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/ConfigurationServiceCollectionExtensionsTests.cs
@@ -1,0 +1,51 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Providers.Configuration.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="ConfigurationServiceCollectionExtensions"/>.
+/// </summary>
+public sealed class ConfigurationServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Verifies that the extension registers ISecretStore + IConfigSource and persists
+    /// the supplied IConfiguration in the container.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithConfiguration_RegistersStoreAndConfigSource()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Secrets:ApiKey"] = "secret-value",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddVaultWithConfiguration(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<ISecretStore>());
+        Assert.NotNull(provider.GetService<IConfigSource>());
+        Assert.Same(configuration, provider.GetRequiredService<IConfiguration>());
+    }
+
+    /// <summary>
+    /// Verifies that null services/configuration arguments are rejected.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithConfiguration_ThrowsArgumentNullException_OnNullArguments()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            ConfigurationServiceCollectionExtensions.AddVaultWithConfiguration(services: null!, configuration));
+        Assert.Throws<ArgumentNullException>(() =>
+            new ServiceCollection().AddVaultWithConfiguration(configuration: null!));
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/FileVaultServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/FileVaultServiceCollectionExtensionsTests.cs
@@ -16,7 +16,7 @@ public sealed class FileVaultServiceCollectionExtensionsTests : IDisposable
     /// </summary>
     public FileVaultServiceCollectionExtensionsTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"vault-file-ext-{Guid.NewGuid():N}");
+        _tempDir = Path.Join(Path.GetTempPath(), $"vault-file-ext-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }
 
@@ -46,8 +46,8 @@ public sealed class FileVaultServiceCollectionExtensionsTests : IDisposable
 
         services.AddVaultWithFile(options =>
         {
-            options.SecretsFilePath = Path.Combine(_tempDir, "secrets.json");
-            options.ConfigFilePath = Path.Combine(_tempDir, "config.json");
+            options.SecretsFilePath = Path.Join(_tempDir, "secrets.json");
+            options.ConfigFilePath = Path.Join(_tempDir, "config.json");
             options.CreateIfNotExists = true;
         });
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/FileVaultServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/FileVaultServiceCollectionExtensionsTests.cs
@@ -1,0 +1,72 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Providers.File.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="FileVaultServiceCollectionExtensions"/>.
+/// </summary>
+public sealed class FileVaultServiceCollectionExtensionsTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileVaultServiceCollectionExtensionsTests"/> class with a scratch directory for backing files.
+    /// </summary>
+    public FileVaultServiceCollectionExtensionsTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"vault-file-ext-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    /// <summary>
+    /// Cleans up the scratch directory.
+    /// </summary>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        catch
+        {
+            // best-effort
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the no-arg overload registers ISecretStore + IConfigSource.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithFile_NoArgs_RegistersStores()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddVaultWithFile(options =>
+        {
+            options.SecretsFilePath = Path.Combine(_tempDir, "secrets.json");
+            options.ConfigFilePath = Path.Combine(_tempDir, "config.json");
+            options.CreateIfNotExists = true;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<ISecretStore>());
+        Assert.NotNull(provider.GetService<IConfigSource>());
+        Assert.NotNull(provider.GetService<ISecretProvider>());
+        Assert.NotNull(provider.GetService<IConfigProvider>());
+    }
+
+    /// <summary>
+    /// Verifies that null services/configure arguments are rejected.
+    /// </summary>
+    [Fact]
+    public void AddVaultWithFile_ThrowsArgumentNullException_OnNullArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            FileVaultServiceCollectionExtensions.AddVaultWithFile(services: null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            new ServiceCollection().AddVaultWithFile(configure: null!));
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/InMemoryServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/InMemoryServiceCollectionExtensionsTests.cs
@@ -1,0 +1,60 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Providers.InMemory.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="InMemoryServiceCollectionExtensions"/>.
+/// </summary>
+public sealed class InMemoryServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Verifies that the no-arg overload wires both stores plus the resolvable composite ISecretStore.
+    /// </summary>
+    [Fact]
+    public void AddVaultInMemory_NoArgs_RegistersStores()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddVaultInMemory();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<ISecretStore>());
+        Assert.NotNull(provider.GetService<IConfigSource>());
+    }
+
+    /// <summary>
+    /// Verifies that the configure overload runs and the extension does not throw
+    /// when seed values are added.
+    /// </summary>
+    [Fact]
+    public void AddVaultInMemory_WithConfigure_AcceptsSeedValues()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddVaultInMemory(options =>
+        {
+            options.AddSecret("api-key", "secret-value");
+            options.AddConfigValue("App:Name", "Vault");
+        });
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<ISecretStore>());
+        Assert.NotNull(provider.GetService<IConfigSource>());
+    }
+
+    /// <summary>
+    /// Verifies that null guards reject null services/configure.
+    /// </summary>
+    [Fact]
+    public void AddVaultInMemory_ThrowsArgumentNullException_OnNullArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            InMemoryServiceCollectionExtensions.AddVaultInMemory(services: null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            new ServiceCollection().AddVaultInMemory(configure: null!));
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/VaultEventGridServiceCollectionExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/VaultEventGridServiceCollectionExtensionsTests.cs
@@ -1,0 +1,42 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.EventGrid.Extensions;
+using HoneyDrunk.Vault.EventGrid.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+
+namespace HoneyDrunk.Vault.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="VaultEventGridServiceCollectionExtensions"/>.
+/// </summary>
+public sealed class VaultEventGridServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Verifies that the extension registers both invalidation handlers and that they
+    /// resolve from the container with their secret-store/invalidator dependencies.
+    /// </summary>
+    [Fact]
+    public void AddVaultEventGridInvalidation_RegistersWebhookAndFunctionHandlers()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<ISecretStore>());
+        services.AddSingleton(Substitute.For<ISecretCacheInvalidator>());
+
+        services.AddVaultEventGridInvalidation();
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<VaultInvalidationWebhookHandler>());
+        Assert.NotNull(provider.GetService<VaultInvalidationFunctionHandler>());
+    }
+
+    /// <summary>
+    /// Verifies that null services arguments are rejected.
+    /// </summary>
+    [Fact]
+    public void AddVaultEventGridInvalidation_ThrowsArgumentNullException_OnNullServices()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            VaultEventGridServiceCollectionExtensions.AddVaultEventGridInvalidation(services: null!));
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Health/VaultHealthContributorTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Health/VaultHealthContributorTests.cs
@@ -168,17 +168,12 @@ public sealed class VaultHealthContributorTests
             return exception is null ? Task.FromResult(isHealthy) : Task.FromException<bool>(exception);
         }
 
-        public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
+        public Task<SecretValue> GetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }
 
-        public Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
-        {
-            throw new NotSupportedException();
-        }
-
-        public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Health/VaultReadinessContributorTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Health/VaultReadinessContributorTests.cs
@@ -203,17 +203,12 @@ public sealed class VaultReadinessContributorTests
             return exception is null ? Task.FromResult(isHealthy) : Task.FromException<bool>(exception);
         }
 
-        public Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
+        public Task<SecretValue> GetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }
 
-        public Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
-        {
-            throw new NotSupportedException();
-        }
-
-        public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(string secretName, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/HoneyDrunk.Vault.Tests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\HoneyDrunk.Vault.Providers.File\HoneyDrunk.Vault.Providers.File.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Vault.Providers.AppConfiguration\HoneyDrunk.Vault.Providers.AppConfiguration.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Vault.Providers.AzureKeyVault\HoneyDrunk.Vault.Providers.AzureKeyVault.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Vault.Providers.Aws\HoneyDrunk.Vault.Providers.Aws.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Vault.EventGrid\HoneyDrunk.Vault.EventGrid.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Vault\HoneyDrunk.Vault.csproj" />
   </ItemGroup>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Models/VaultScopeTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Models/VaultScopeTests.cs
@@ -1,0 +1,62 @@
+using HoneyDrunk.Vault.Models;
+
+namespace HoneyDrunk.Vault.Tests.Models;
+
+/// <summary>
+/// Tests for <see cref="VaultScope"/>.
+/// </summary>
+public sealed class VaultScopeTests
+{
+    /// <summary>
+    /// Verifies that the single-arg constructor leaves tenant/node null.
+    /// </summary>
+    [Fact]
+    public void EnvironmentOnlyConstructor_DefaultsTenantAndNodeToNull()
+    {
+        var scope = new VaultScope("production");
+
+        Assert.Equal("production", scope.Environment);
+        Assert.Null(scope.Tenant);
+        Assert.Null(scope.Node);
+    }
+
+    /// <summary>
+    /// Verifies that the full constructor stores all three components.
+    /// </summary>
+    [Fact]
+    public void FullConstructor_StoresAllComponents()
+    {
+        var scope = new VaultScope("production", "tenant-42", "node-7");
+
+        Assert.Equal("production", scope.Environment);
+        Assert.Equal("tenant-42", scope.Tenant);
+        Assert.Equal("node-7", scope.Node);
+    }
+
+    /// <summary>
+    /// Verifies that null/whitespace environment values are rejected.
+    /// </summary>
+    /// <param name="environment">The invalid environment name to test.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_ThrowsArgumentException_ForInvalidEnvironment(string? environment)
+    {
+        Assert.Throws<ArgumentException>(() => new VaultScope(environment!));
+        Assert.Throws<ArgumentException>(() => new VaultScope(environment!, "tenant", "node"));
+    }
+
+    /// <summary>
+    /// Verifies that VaultScope is value-equal as a record.
+    /// </summary>
+    [Fact]
+    public void RecordEquality_ReturnsTrue_ForMatchingValues()
+    {
+        var a = new VaultScope("production", "tenant", "node");
+        var b = new VaultScope("production", "tenant", "node");
+
+        Assert.Equal(a, b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/AwsSecretsManagerSecretStoreTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/AwsSecretsManagerSecretStoreTests.cs
@@ -29,7 +29,7 @@ public sealed class AwsSecretsManagerSecretStoreTests
             .Returns(new GetSecretValueResponse
             {
                 SecretString = "secret-value",
-                VersionStages = new List<string> { "AWSCURRENT" },
+                VersionStages = ["AWSCURRENT"],
             });
 
         // UseVersionId = false → the secret store reports the version stage instead of the GUID.
@@ -53,7 +53,7 @@ public sealed class AwsSecretsManagerSecretStoreTests
             {
                 SecretString = "value",
                 VersionId = "00000000000000000000000000000001",
-                VersionStages = new List<string> { "AWSCURRENT" },
+                VersionStages = ["AWSCURRENT"],
             });
 
         using var store = CreateStore(client, new AwsSecretsManagerOptions { UseVersionId = true });
@@ -103,7 +103,7 @@ public sealed class AwsSecretsManagerSecretStoreTests
     {
         var client = Substitute.For<IAmazonSecretsManager>();
         client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
-            .Returns(new GetSecretValueResponse { SecretString = "v", VersionStages = new List<string> { "AWSCURRENT" } });
+            .Returns(new GetSecretValueResponse { SecretString = "v", VersionStages = ["AWSCURRENT"] });
 
         using var store = CreateStore(client, new AwsSecretsManagerOptions { SecretPrefix = "prod/" });
         await store.GetSecretAsync(new SecretIdentifier("api-key"));
@@ -124,14 +124,14 @@ public sealed class AwsSecretsManagerSecretStoreTests
         client.ListSecretVersionIdsAsync(Arg.Any<ListSecretVersionIdsRequest>(), Arg.Any<CancellationToken>())
             .Returns(new ListSecretVersionIdsResponse
             {
-                Versions = new List<SecretVersionsListEntry>
-                {
-                    new SecretVersionsListEntry
+                Versions =
+                [
+                    new()
                     {
-                        VersionStages = new List<string> { "AWSCURRENT" },
+                        VersionStages = ["AWSCURRENT"],
                         CreatedDate = DateTime.UtcNow,
                     },
-                },
+                ],
             });
 
         using var store = CreateStore(client, new AwsSecretsManagerOptions { UseVersionId = false });
@@ -210,12 +210,17 @@ public sealed class AwsSecretsManagerSecretStoreTests
     {
         var client = Substitute.For<IAmazonSecretsManager>();
 
-        // The `using` block's automatic Dispose IS the second call. If the
-        // explicit store.Dispose() below throws, the using cleanup still runs
-        // (CodeQL cs/dispose-not-called-on-throw); if the explicit Dispose
-        // succeeds, the using cleanup then verifies the idempotent path.
-        using var store = CreateStore(client);
-        store.Dispose();
+        // The `using` declaration calls Dispose at scope exit (second call);
+        // the explicit store.Dispose() inside is the first call. Record.Exception
+        // captures any throw from either call, and the Assert.Null gives Sonar
+        // its mandatory assertion (S2699).
+        var exception = Record.Exception(() =>
+        {
+            using var store = CreateStore(client);
+            store.Dispose();
+        });
+
+        Assert.Null(exception);
     }
 
     private static AwsSecretsManagerSecretStore CreateStore(

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/AwsSecretsManagerSecretStoreTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/AwsSecretsManagerSecretStoreTests.cs
@@ -1,0 +1,227 @@
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Model;
+using HoneyDrunk.Vault.Exceptions;
+using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Providers.Aws.Configuration;
+using HoneyDrunk.Vault.Providers.Aws.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace HoneyDrunk.Vault.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="AwsSecretsManagerSecretStore"/> using NSubstitute against
+/// <see cref="IAmazonSecretsManager"/>.
+/// </summary>
+public sealed class AwsSecretsManagerSecretStoreTests
+{
+    /// <summary>
+    /// Verifies that GetSecretAsync returns the secret value and version when the
+    /// SDK returns a successful response.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetSecretAsync_ReturnsSecretValue()
+    {
+        var client = Substitute.For<IAmazonSecretsManager>();
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new GetSecretValueResponse
+            {
+                SecretString = "secret-value",
+                VersionStages = new List<string> { "AWSCURRENT" },
+            });
+
+        // UseVersionId = false → the secret store reports the version stage instead of the GUID.
+        using var store = CreateStore(client, new AwsSecretsManagerOptions { UseVersionId = false });
+        var value = await store.GetSecretAsync(new SecretIdentifier("api-key"));
+
+        Assert.Equal("secret-value", value.Value);
+        Assert.Equal("AWSCURRENT", value.Version);
+    }
+
+    /// <summary>
+    /// Verifies that GetSecretAsync prefers VersionId when UseVersionId is enabled.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetSecretAsync_UsesVersionId_WhenConfigured()
+    {
+        var client = Substitute.For<IAmazonSecretsManager>();
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new GetSecretValueResponse
+            {
+                SecretString = "value",
+                VersionId = "00000000000000000000000000000001",
+                VersionStages = new List<string> { "AWSCURRENT" },
+            });
+
+        using var store = CreateStore(client, new AwsSecretsManagerOptions { UseVersionId = true });
+        var value = await store.GetSecretAsync(new SecretIdentifier("api-key"));
+
+        Assert.Equal("00000000000000000000000000000001", value.Version);
+    }
+
+    /// <summary>
+    /// Verifies that GetSecretAsync wraps ResourceNotFoundException as SecretNotFoundException.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetSecretAsync_WrapsResourceNotFound()
+    {
+        var client = Substitute.For<IAmazonSecretsManager>();
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns<Task<GetSecretValueResponse>>(_ => throw new ResourceNotFoundException("missing"));
+
+        using var store = CreateStore(client);
+        await Assert.ThrowsAsync<SecretNotFoundException>(
+            () => store.GetSecretAsync(new SecretIdentifier("missing")));
+    }
+
+    /// <summary>
+    /// Verifies that GetSecretAsync wraps generic AWS exceptions as VaultOperationException.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetSecretAsync_WrapsAmazonException()
+    {
+        var client = Substitute.For<IAmazonSecretsManager>();
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns<Task<GetSecretValueResponse>>(_ => throw new AmazonSecretsManagerException("boom"));
+
+        using var store = CreateStore(client);
+        await Assert.ThrowsAsync<VaultOperationException>(
+            () => store.GetSecretAsync(new SecretIdentifier("any")));
+    }
+
+    /// <summary>
+    /// Verifies that the secret prefix is applied to the lookup key.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetSecretAsync_AppliesSecretPrefix()
+    {
+        var client = Substitute.For<IAmazonSecretsManager>();
+        client.GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new GetSecretValueResponse { SecretString = "v", VersionStages = new List<string> { "AWSCURRENT" } });
+
+        using var store = CreateStore(client, new AwsSecretsManagerOptions { SecretPrefix = "prod/" });
+        await store.GetSecretAsync(new SecretIdentifier("api-key"));
+
+        await client.Received().GetSecretValueAsync(
+            Arg.Is<GetSecretValueRequest>(r => r.SecretId == "prod/api-key"),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies that ListSecretVersionsAsync returns the paginated versions.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ListSecretVersionsAsync_ReturnsVersions()
+    {
+        var client = Substitute.For<IAmazonSecretsManager>();
+        client.ListSecretVersionIdsAsync(Arg.Any<ListSecretVersionIdsRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ListSecretVersionIdsResponse
+            {
+                Versions = new List<SecretVersionsListEntry>
+                {
+                    new SecretVersionsListEntry
+                    {
+                        VersionStages = new List<string> { "AWSCURRENT" },
+                        CreatedDate = DateTime.UtcNow,
+                    },
+                },
+            });
+
+        using var store = CreateStore(client, new AwsSecretsManagerOptions { UseVersionId = false });
+        var versions = await store.ListSecretVersionsAsync("api-key");
+
+        Assert.Single(versions);
+        Assert.Equal("AWSCURRENT", versions[0].Version);
+    }
+
+    /// <summary>
+    /// Verifies that ListSecretVersionsAsync wraps ResourceNotFoundException.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ListSecretVersionsAsync_WrapsResourceNotFound()
+    {
+        var client = Substitute.For<IAmazonSecretsManager>();
+        client.ListSecretVersionIdsAsync(Arg.Any<ListSecretVersionIdsRequest>(), Arg.Any<CancellationToken>())
+            .Returns<Task<ListSecretVersionIdsResponse>>(_ => throw new ResourceNotFoundException("missing"));
+
+        using var store = CreateStore(client);
+        await Assert.ThrowsAsync<SecretNotFoundException>(
+            () => store.ListSecretVersionsAsync("missing"));
+    }
+
+    /// <summary>
+    /// Verifies that CheckHealthAsync reports true on a successful list-secrets call.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsTrue_OnSuccessfulPing()
+    {
+        var client = Substitute.For<IAmazonSecretsManager>();
+        client.ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new ListSecretsResponse());
+
+        using var store = CreateStore(client);
+
+        Assert.True(await store.CheckHealthAsync());
+    }
+
+    /// <summary>
+    /// Verifies that CheckHealthAsync swallows exceptions and reports false.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsFalse_OnException()
+    {
+        var client = Substitute.For<IAmazonSecretsManager>();
+        client.ListSecretsAsync(Arg.Any<ListSecretsRequest>(), Arg.Any<CancellationToken>())
+            .Returns<Task<ListSecretsResponse>>(_ => throw new InvalidOperationException("boom"));
+
+        using var store = CreateStore(client);
+
+        Assert.False(await store.CheckHealthAsync());
+    }
+
+    /// <summary>
+    /// Verifies that constructor rejects null options.
+    /// </summary>
+    [Fact]
+    public void Constructor_ThrowsForNullOptions()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new AwsSecretsManagerSecretStore(
+                options: null!,
+                Substitute.For<IAmazonSecretsManager>(),
+                NullLogger<AwsSecretsManagerSecretStore>.Instance));
+    }
+
+    /// <summary>
+    /// Verifies that Dispose does not throw and is idempotent.
+    /// </summary>
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var client = Substitute.For<IAmazonSecretsManager>();
+        var store = CreateStore(client);
+
+        store.Dispose();
+        store.Dispose();
+    }
+
+    private static AwsSecretsManagerSecretStore CreateStore(
+        IAmazonSecretsManager client,
+        AwsSecretsManagerOptions? options = null)
+    {
+        return new AwsSecretsManagerSecretStore(
+            Options.Create(options ?? new AwsSecretsManagerOptions()),
+            client,
+            NullLogger<AwsSecretsManagerSecretStore>.Instance);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/AwsSecretsManagerSecretStoreTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/AwsSecretsManagerSecretStoreTests.cs
@@ -209,19 +209,13 @@ public sealed class AwsSecretsManagerSecretStoreTests
     public void Dispose_IsIdempotent()
     {
         var client = Substitute.For<IAmazonSecretsManager>();
-        var store = CreateStore(client);
 
-        try
-        {
-            store.Dispose();
-        }
-        finally
-        {
-            // Second call must not throw — that is the property under test.
-            // Wrapping in try/finally guarantees the resource is still released
-            // if the first Dispose somehow throws (CodeQL cs/dispose-not-called-on-throw).
-            store.Dispose();
-        }
+        // The `using` block's automatic Dispose IS the second call. If the
+        // explicit store.Dispose() below throws, the using cleanup still runs
+        // (CodeQL cs/dispose-not-called-on-throw); if the explicit Dispose
+        // succeeds, the using cleanup then verifies the idempotent path.
+        using var store = CreateStore(client);
+        store.Dispose();
     }
 
     private static AwsSecretsManagerSecretStore CreateStore(

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/AwsSecretsManagerSecretStoreTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/AwsSecretsManagerSecretStoreTests.cs
@@ -211,8 +211,17 @@ public sealed class AwsSecretsManagerSecretStoreTests
         var client = Substitute.For<IAmazonSecretsManager>();
         var store = CreateStore(client);
 
-        store.Dispose();
-        store.Dispose();
+        try
+        {
+            store.Dispose();
+        }
+        finally
+        {
+            // Second call must not throw — that is the property under test.
+            // Wrapping in try/finally guarantees the resource is still released
+            // if the first Dispose somehow throws (CodeQL cs/dispose-not-called-on-throw).
+            store.Dispose();
+        }
     }
 
     private static AwsSecretsManagerSecretStore CreateStore(

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/AzureKeyVaultConfigSourceTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/AzureKeyVaultConfigSourceTests.cs
@@ -1,0 +1,156 @@
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Exceptions;
+using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace HoneyDrunk.Vault.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="AzureKeyVaultConfigSource"/>. The implementation delegates to
+/// <see cref="ISecretStore"/>, so the tests substitute the store rather than the
+/// underlying <c>SecretClient</c> SDK type.
+/// </summary>
+public sealed class AzureKeyVaultConfigSourceTests
+{
+    /// <summary>
+    /// Verifies that GetConfigValueAsync returns the secret value when the underlying
+    /// secret resolves.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetConfigValueAsync_ReturnsSecretValue()
+    {
+        var secretStore = Substitute.For<ISecretStore>();
+        var identifier = new SecretIdentifier("App-Name");
+        secretStore.GetSecretAsync(Arg.Any<SecretIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(new SecretValue(identifier, "Vault", "latest"));
+        var source = new AzureKeyVaultConfigSource(secretStore, NullLogger<AzureKeyVaultConfigSource>.Instance);
+
+        var value = await source.GetConfigValueAsync("App-Name");
+
+        Assert.Equal("Vault", value);
+    }
+
+    /// <summary>
+    /// Verifies that GetConfigValueAsync normalizes colon-separated keys to hyphenated
+    /// Key Vault names before calling the secret store.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetConfigValueAsync_NormalizesColonAndDoubleUnderscoreKeys()
+    {
+        var secretStore = Substitute.For<ISecretStore>();
+        secretStore.GetSecretAsync(Arg.Any<SecretIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => new SecretValue(callInfo.Arg<SecretIdentifier>(), "ok", "latest"));
+        var source = new AzureKeyVaultConfigSource(secretStore, NullLogger<AzureKeyVaultConfigSource>.Instance);
+
+        await source.GetConfigValueAsync("Section:Sub__Key.Dotted");
+
+        await secretStore.Received().GetSecretAsync(
+            Arg.Is<SecretIdentifier>(id => id.Name == "Section-Sub-Key-Dotted"),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies that GetConfigValueAsync wraps SecretNotFoundException as
+    /// ConfigurationNotFoundException.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetConfigValueAsync_WrapsSecretNotFoundAsConfigurationNotFound()
+    {
+        var secretStore = Substitute.For<ISecretStore>();
+        secretStore.GetSecretAsync(Arg.Any<SecretIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns<Task<SecretValue>>(_ => throw new SecretNotFoundException("missing"));
+        var source = new AzureKeyVaultConfigSource(secretStore, NullLogger<AzureKeyVaultConfigSource>.Instance);
+
+        await Assert.ThrowsAsync<ConfigurationNotFoundException>(
+            () => source.GetConfigValueAsync("missing"));
+    }
+
+    /// <summary>
+    /// Verifies that GetConfigValueAsync rejects null/whitespace keys.
+    /// </summary>
+    /// <param name="key">The invalid key to test.</param>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GetConfigValueAsync_ThrowsForInvalidKey(string? key)
+    {
+        var source = new AzureKeyVaultConfigSource(
+            Substitute.For<ISecretStore>(),
+            NullLogger<AzureKeyVaultConfigSource>.Instance);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => source.GetConfigValueAsync(key!));
+    }
+
+    /// <summary>
+    /// Verifies that TryGetConfigValueAsync returns the value on success.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task TryGetConfigValueAsync_ReturnsValue_OnSuccess()
+    {
+        var secretStore = Substitute.For<ISecretStore>();
+        var identifier = new SecretIdentifier("App-Name");
+        secretStore.TryGetSecretAsync(Arg.Any<SecretIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(VaultResult.Success(new SecretValue(identifier, "Vault", "latest")));
+        var source = new AzureKeyVaultConfigSource(secretStore, NullLogger<AzureKeyVaultConfigSource>.Instance);
+
+        var value = await source.TryGetConfigValueAsync("App-Name");
+
+        Assert.Equal("Vault", value);
+    }
+
+    /// <summary>
+    /// Verifies that TryGetConfigValueAsync returns null when the store returns a failure
+    /// result.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task TryGetConfigValueAsync_ReturnsNull_OnFailureResult()
+    {
+        var secretStore = Substitute.For<ISecretStore>();
+        secretStore.TryGetSecretAsync(Arg.Any<SecretIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns(VaultResult.Failure<SecretValue>("not found"));
+        var source = new AzureKeyVaultConfigSource(secretStore, NullLogger<AzureKeyVaultConfigSource>.Instance);
+
+        var value = await source.TryGetConfigValueAsync("missing");
+
+        Assert.Null(value);
+    }
+
+    /// <summary>
+    /// Verifies that TryGetConfigValueAsync swallows exceptions from the store and
+    /// returns null.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task TryGetConfigValueAsync_ReturnsNull_OnStoreException()
+    {
+        var secretStore = Substitute.For<ISecretStore>();
+        secretStore.TryGetSecretAsync(Arg.Any<SecretIdentifier>(), Arg.Any<CancellationToken>())
+            .Returns<Task<VaultResult<SecretValue>>>(_ => throw new InvalidOperationException("boom"));
+        var source = new AzureKeyVaultConfigSource(secretStore, NullLogger<AzureKeyVaultConfigSource>.Instance);
+
+        var value = await source.TryGetConfigValueAsync("App-Name");
+
+        Assert.Null(value);
+    }
+
+    /// <summary>
+    /// Verifies that constructor rejects null arguments.
+    /// </summary>
+    [Fact]
+    public void Constructor_ThrowsForNullArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new AzureKeyVaultConfigSource(null!, NullLogger<AzureKeyVaultConfigSource>.Instance));
+        Assert.Throws<ArgumentNullException>(() =>
+            new AzureKeyVaultConfigSource(Substitute.For<ISecretStore>(), null!));
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/ConfigurationProviderTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/ConfigurationProviderTests.cs
@@ -1,3 +1,4 @@
+using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Providers.Configuration.Services;
@@ -171,7 +172,7 @@ public sealed class ConfigurationProviderTests
         var store = CreateSecretStore([]);
 
         // Act
-        var result = await store.TryGetSecretAsync(new SecretIdentifier("missing"));
+        var result = await ((ISecretStore)store).TryGetSecretAsync(new SecretIdentifier("missing"));
 
         // Assert
         Assert.False(result.IsSuccess);

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/FileSecretStoreTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/FileSecretStoreTests.cs
@@ -1,3 +1,4 @@
+using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Providers.File.Configuration;
@@ -98,7 +99,7 @@ public sealed class FileSecretStoreTests : IDisposable
         var identifier = new SecretIdentifier("non-existent");
 
         // Act
-        var result = await _store.TryGetSecretAsync(identifier);
+        var result = await ((ISecretStore)_store).TryGetSecretAsync(identifier);
 
         // Assert
         Assert.False(result.IsSuccess);
@@ -112,7 +113,7 @@ public sealed class FileSecretStoreTests : IDisposable
     public async Task TryGetSecretAsync_ThrowsForNullIdentifier()
     {
         // Act & Assert
-        await Assert.ThrowsAsync<ArgumentNullException>(() => _store.TryGetSecretAsync(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => ((ISecretStore)_store).TryGetSecretAsync(null!));
     }
 
     /// <summary>
@@ -149,7 +150,7 @@ public sealed class FileSecretStoreTests : IDisposable
     public async Task FetchSecretAsync_ThrowsSecretNotFoundException_ForNonExistentSecret()
     {
         // Act & Assert
-        await Assert.ThrowsAsync<SecretNotFoundException>(() => _store.FetchSecretAsync("non-existent"));
+        await Assert.ThrowsAsync<SecretNotFoundException>(() => ((ISecretProvider)_store).FetchSecretAsync("non-existent"));
     }
 
     /// <summary>
@@ -160,7 +161,7 @@ public sealed class FileSecretStoreTests : IDisposable
     public async Task TryFetchSecretAsync_ReturnsFailure_ForNonExistentSecret()
     {
         // Act
-        var result = await _store.TryFetchSecretAsync("non-existent");
+        var result = await ((ISecretProvider)_store).TryFetchSecretAsync("non-existent");
 
         // Assert
         Assert.False(result.IsSuccess);

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/FileSecretStoreWithSecretsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/FileSecretStoreWithSecretsTests.cs
@@ -1,3 +1,4 @@
+using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Providers.File.Configuration;
 using HoneyDrunk.Vault.Providers.File.Services;
@@ -75,7 +76,7 @@ public sealed class FileSecretStoreWithSecretsTests : IDisposable
         var identifier = new SecretIdentifier("connection-string");
 
         // Act
-        var result = await _store.TryGetSecretAsync(identifier);
+        var result = await ((ISecretStore)_store).TryGetSecretAsync(identifier);
 
         // Assert
         Assert.True(result.IsSuccess);
@@ -106,7 +107,7 @@ public sealed class FileSecretStoreWithSecretsTests : IDisposable
     public async Task FetchSecretAsync_ReturnsSecret()
     {
         // Act
-        var result = await _store.FetchSecretAsync("api-key");
+        var result = await ((ISecretProvider)_store).FetchSecretAsync("api-key");
 
         // Assert
         Assert.Equal("secret-value", result.Value);
@@ -120,7 +121,7 @@ public sealed class FileSecretStoreWithSecretsTests : IDisposable
     public async Task TryFetchSecretAsync_ReturnsSuccess_ForExistingSecret()
     {
         // Act
-        var result = await _store.TryFetchSecretAsync("api-key");
+        var result = await ((ISecretProvider)_store).TryFetchSecretAsync("api-key");
 
         // Assert
         Assert.True(result.IsSuccess);

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/InMemorySecretStoreTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Services/InMemorySecretStoreTests.cs
@@ -1,3 +1,4 @@
+using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Exceptions;
 using HoneyDrunk.Vault.Models;
 using HoneyDrunk.Vault.Providers.InMemory.Services;
@@ -72,7 +73,7 @@ public sealed class InMemorySecretStoreTests
         _secrets[secretName] = secretValue;
 
         // Act
-        var result = await _store.TryGetSecretAsync(new SecretIdentifier(secretName));
+        var result = await ((ISecretStore)_store).TryGetSecretAsync(new SecretIdentifier(secretName));
 
         // Assert
         Assert.True(result.IsSuccess);
@@ -87,7 +88,7 @@ public sealed class InMemorySecretStoreTests
     public async Task TryGetSecretAsync_ReturnsFailure_WhenSecretNotExists()
     {
         // Act
-        var result = await _store.TryGetSecretAsync(new SecretIdentifier("missing"));
+        var result = await ((ISecretStore)_store).TryGetSecretAsync(new SecretIdentifier("missing"));
 
         // Assert
         Assert.False(result.IsSuccess);
@@ -241,7 +242,7 @@ public sealed class InMemorySecretStoreTests
         _secrets[secretName] = secretValue;
 
         // Act
-        var result = await _store.FetchSecretAsync(secretName);
+        var result = await ((ISecretProvider)_store).FetchSecretAsync(secretName);
 
         // Assert
         Assert.Equal(secretValue, result.Value);

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Abstractions/ISecretProvider.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Abstractions/ISecretProvider.cs
@@ -1,4 +1,5 @@
 using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Services;
 
 namespace HoneyDrunk.Vault.Abstractions;
 
@@ -6,7 +7,16 @@ namespace HoneyDrunk.Vault.Abstractions;
 /// Defines the contract for a backend-specific secret provider.
 /// Implementations provide access to secrets from a specific backend (file, Azure Key Vault, AWS, etc.).
 /// </summary>
-public interface ISecretProvider
+/// <remarks>
+/// Extends <see cref="ISecretStore"/> with backend-aware metadata
+/// (<see cref="ProviderName"/>, <see cref="IsAvailable"/>, <see cref="CheckHealthAsync(System.Threading.CancellationToken)"/>).
+/// The provider-key-flavored fetch overloads
+/// (<see cref="FetchSecretAsync"/>, <see cref="TryFetchSecretAsync"/>, <see cref="ListVersionsAsync"/>)
+/// have default interface implementations that delegate to <see cref="SecretStoreFacade"/>
+/// against the inherited <see cref="ISecretStore"/> members; implementers only override when
+/// they need provider-specific behavior.
+/// </remarks>
+public interface ISecretProvider : ISecretStore
 {
     /// <summary>
     /// Gets the logical name of this provider (e.g., "file", "azure-keyvault", "aws-secretsmanager").
@@ -25,7 +35,10 @@ public interface ISecretProvider
     /// <param name="version">The optional secret version.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The secret value.</returns>
-    Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default);
+    Task<SecretValue> FetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
+    {
+        return SecretStoreFacade.FetchSecretAsync(GetSecretAsync, key, version, cancellationToken);
+    }
 
     /// <summary>
     /// Attempts to fetch a secret from the backend.
@@ -34,7 +47,10 @@ public interface ISecretProvider
     /// <param name="version">The optional secret version.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A result containing the secret value if found, or a failure result.</returns>
-    Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default);
+    Task<VaultResult<SecretValue>> TryFetchSecretAsync(string key, string? version = null, CancellationToken cancellationToken = default)
+    {
+        return SecretStoreFacade.TryFetchSecretAsync(TryGetSecretAsync, key, version, cancellationToken);
+    }
 
     /// <summary>
     /// Lists all versions of a secret from the backend.
@@ -42,7 +58,10 @@ public interface ISecretProvider
     /// <param name="key">The secret key/name.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A collection of secret versions.</returns>
-    Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(string key, CancellationToken cancellationToken = default)
+    {
+        return SecretStoreFacade.ListVersionsAsync(ListSecretVersionsAsync, key, cancellationToken);
+    }
 
     /// <summary>
     /// Checks if the provider is healthy and can communicate with its backend.

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Abstractions/ISecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Abstractions/ISecretStore.cs
@@ -34,7 +34,7 @@ public interface ISecretStore
     /// <returns>A result containing the secret value if found, or a failure result.</returns>
     async Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
     {
-        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, logger: null, storeName: null, cancellationToken).ConfigureAwait(false);
+        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, logger: null, storeName: null, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Abstractions/ISecretStore.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Abstractions/ISecretStore.cs
@@ -1,10 +1,21 @@
 using HoneyDrunk.Vault.Models;
+using HoneyDrunk.Vault.Services;
 
 namespace HoneyDrunk.Vault.Abstractions;
 
 /// <summary>
 /// Defines the contract for a secret store provider.
 /// </summary>
+/// <remarks>
+/// Concrete implementations supply the two operations that touch the backend
+/// (<see cref="GetSecretAsync(SecretIdentifier, System.Threading.CancellationToken)"/> and
+/// <see cref="ListSecretVersionsAsync(string, System.Threading.CancellationToken)"/>).
+/// <see cref="TryGetSecretAsync(SecretIdentifier, System.Threading.CancellationToken)"/>
+/// is supplied as a default interface method that delegates to
+/// <see cref="SecretStoreFacade"/> against <see cref="GetSecretAsync(SecretIdentifier, System.Threading.CancellationToken)"/>
+/// (the default implementation logs nothing — <c>logger: null</c>). Implementers
+/// only override it when they need provider-specific telemetry.
+/// </remarks>
 public interface ISecretStore
 {
     /// <summary>
@@ -21,7 +32,10 @@ public interface ISecretStore
     /// <param name="identifier">The secret identifier.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A result containing the secret value if found, or a failure result.</returns>
-    Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default);
+    async Task<VaultResult<SecretValue>> TryGetSecretAsync(SecretIdentifier identifier, CancellationToken cancellationToken = default)
+    {
+        return await SecretStoreFacade.TryGetSecretAsync(identifier, GetSecretAsync, logger: null, storeName: null, cancellationToken).ConfigureAwait(false);
+    }
 
     /// <summary>
     /// Lists all versions of a secret.

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-27
+
+### Changed (breaking)
+- `ISecretProvider` now extends `ISecretStore`. Implementations must also satisfy the `GetSecretAsync` / `ListSecretVersionsAsync` shape (Configuration is the only secret store that intentionally remains an `ISecretStore`-only). The `FetchSecretAsync`, `TryFetchSecretAsync`, and `ListVersionsAsync` overloads on `ISecretProvider` are now **default interface methods** that delegate to `SecretStoreFacade` against the inherited `ISecretStore` members — implementations should drop their redundant overrides. Callers that previously invoked these methods on the concrete provider class must now reach them through the `ISecretProvider` interface (or the new `((ISecretProvider)store).Fetch*` cast pattern).
+- `ISecretStore.TryGetSecretAsync` is also a default interface method now (delegating to `GetSecretAsync` via `SecretStoreFacade` with `logger: null`). Concrete implementers may drop the redundant override; callers must hit `ISecretStore.TryGetSecretAsync` through the interface (cast or DI). The previous per-class overrides logged a richer "Attempting to get…" debug line and the catch-path debug/error lines — same behavioral nit acknowledged for `IConfigSource.GetConfigValueAsync<T>` in 0.6.0.
+
+### Changed
+- New `DictionarySecretLookup` and `DictionaryConfigLookup` static helpers in `HoneyDrunk.Vault.Services` consolidate the validate-and-log-and-throw pattern used by every dictionary-backed provider (`InMemorySecretStore`, `FileSecretStore`, `InMemoryConfigSource`, `FileConfigSource`). Each provider's `GetSecretAsync` / `ListSecretVersionsAsync` / `GetConfigValueAsync` / `TryGetConfigValueAsync` is now a one-liner delegating to the helper.
+- `AddVaultCore` now resolves `CompositeSecretStore` via a factory that calls `sp.GetService<VaultTelemetry>()` so the optional telemetry parameter binds to `null` when `EnableTelemetry: false` (or when standalone provider extension methods are used without `HoneyDrunkBuilder.AddVault`). It also pre-registers a default `IOptions<VaultOptions>` so the caching factory does not blow up in that standalone flow. Unblocks the standalone DI surface for `services.AddVaultInMemory()` / `services.AddVaultWithFile()` / `services.AddVaultWithConfiguration()` / `services.AddVaultWithAzureKeyVault()` / `services.AddVaultWithAwsSecretsManager()`.
+
+### Internal
+- Sonar duplication reduction (ADR-0011 D11). The "Duplicated Lines on New Code" findings on `InMemorySecretStore` (35.5%), `ConfigurationSecretStore` (25.8%), `FileSecretStore` (21.6%), `InMemoryConfigSource` (18.8%), `AzureKeyVaultSecretStore` (16.0%), `FileConfigSource` (13.7%), `AwsSecretsManagerSecretStore` (10.6%), `CompositeConfigSource` (7.5%), and `CompositeSecretStore` (6.5%) are addressed by the DIM promotion and helper extraction above.
+- Coverage backfill — 53 new tests across `VaultScope`, `InMemoryVaultOptions`, `AzureKeyVaultOptions`, the five `*ServiceCollectionExtensions` for provider packages, `VaultEventGridServiceCollectionExtensions`, `AzureKeyVaultConfigSource`, `AwsSecretsManagerSecretStore`, and `VaultInvalidationFunctionHandler`. Test project now references `HoneyDrunk.Vault.Providers.Aws` directly so the AWS NSubstitute tests can wire `IAmazonSecretsManager`.
+
 ## [0.6.0] - 2026-05-26
 
 ### Changed (breaking)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Extensions/VaultServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Extensions/VaultServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using HoneyDrunk.Vault.Abstractions;
 using HoneyDrunk.Vault.Configuration;
 using HoneyDrunk.Vault.Resilience;
 using HoneyDrunk.Vault.Services;
+using HoneyDrunk.Vault.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -36,8 +37,19 @@ public static class VaultServiceCollectionExtensions
         services.TryAddSingleton<SecretCache>();
         services.TryAddSingleton<ISecretCacheInvalidator>(sp => sp.GetRequiredService<SecretCache>());
 
-        // Register composite secret store (wraps all registered providers)
-        services.TryAddSingleton<CompositeSecretStore>();
+        // Ensure VaultOptions is always resolvable so providers calling AddVaultCore
+        // standalone (without HoneyDrunkBuilder.AddVault) don't blow up on the cache
+        // factory below. AddVault still owns the user-configured registration.
+        services.TryAddSingleton<IOptions<VaultOptions>>(_ => Options.Create(new VaultOptions()));
+
+        // Register composite secret store via a factory so the nullable VaultTelemetry
+        // parameter resolves to null when the kernel-level AddVault didn't register it
+        // (e.g., EnableTelemetry: false or provider extensions used standalone).
+        services.TryAddSingleton(sp => new CompositeSecretStore(
+            sp.GetRequiredService<IEnumerable<RegisteredSecretProvider>>(),
+            sp.GetRequiredService<ResiliencePipelineFactory>(),
+            sp.GetService<VaultTelemetry>(),
+            sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<CompositeSecretStore>>()));
 
         // Register composite config source (wraps all registered providers)
         services.TryAddSingleton<CompositeConfigSource>();

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Extensions/VaultServiceCollectionExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Extensions/VaultServiceCollectionExtensions.cs
@@ -39,8 +39,11 @@ public static class VaultServiceCollectionExtensions
 
         // Ensure VaultOptions is always resolvable so providers calling AddVaultCore
         // standalone (without HoneyDrunkBuilder.AddVault) don't blow up on the cache
-        // factory below. AddVault still owns the user-configured registration.
-        services.TryAddSingleton<IOptions<VaultOptions>>(_ => Options.Create(new VaultOptions()));
+        // factory below. AddOptions<T>() wires the standard options pipeline (via
+        // TryAdd), so a later services.Configure<VaultOptions>(...) is still honored —
+        // unlike a pre-baked Options.Create(...) singleton, which would make the
+        // configuration order-dependent.
+        services.AddOptions<VaultOptions>();
 
         // Register composite secret store via a factory so the nullable VaultTelemetry
         // parameter resolves to null when the kernel-level AddVault didn't register it

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
@@ -9,10 +9,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Secrets and configuration management library for .NET. Provides a unified abstraction for accessing secrets from multiple providers (File, Azure Key Vault, AWS Secrets Manager, Configuration, In-Memory). Integrated with HoneyDrunk.Kernel v0.8.0 for lifecycle management, health reporting, and distributed telemetry.</Description>
-    <PackageReleaseNotes>v0.6.0: Sonar gate-cleanup (ADR-0011 D11). Enable AssemblyVersion generation, drop CA1016 suppression, reorder ConfigSourceFacade.TryGetValueAsync to put CancellationToken last (breaking), refactor health/readiness contributors for cognitive complexity, fix log-without-exception findings, reorder method overloads for adjacency, and align Kernel/Microsoft.Extensions/Azure/AWS SDK references. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.7.0: Sonar duplication reduction (ADR-0011 D11) + coverage backfill. ISecretProvider now extends ISecretStore and exposes the FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync trio as default interface methods delegating to SecretStoreFacade; ISecretStore.TryGetSecretAsync is similarly a DIM (breaking — existing implementers may no longer need the redundant overrides). New DictionarySecretLookup / DictionaryConfigLookup helpers consolidate the in-memory/file-store lookup pattern. AddVaultCore now resolves the composite via a factory so the optional VaultTelemetry parameter binds to null when telemetry is disabled. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;secrets;configuration;provider;cache;resilience;circuit-breaker;retry;azure-keyvault;aws;kernel;grid;distributed-tracing</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/DictionaryConfigLookup.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/DictionaryConfigLookup.cs
@@ -1,0 +1,63 @@
+using HoneyDrunk.Vault.Exceptions;
+using Microsoft.Extensions.Logging;
+
+namespace HoneyDrunk.Vault.Services;
+
+/// <summary>
+/// Shared helpers for dictionary-backed configuration source implementations
+/// (in-memory, file-backed). Centralises the "validate + lookup + log" shape.
+/// </summary>
+public static class DictionaryConfigLookup
+{
+    /// <summary>
+    /// Gets a configuration value from the provided dictionary, throwing
+    /// <see cref="ConfigurationNotFoundException"/> when the key is absent.
+    /// </summary>
+    /// <param name="configValues">The dictionary backing the source.</param>
+    /// <param name="key">The configuration key.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="storeName">A short human label used in log messages.</param>
+    /// <returns>The configuration value.</returns>
+    public static Task<string> GetConfigValueAsync(
+        IDictionary<string, string> configValues,
+        string key,
+        ILogger logger,
+        string storeName)
+    {
+        ArgumentNullException.ThrowIfNull(configValues);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        ConfigSourceFacade.ValidateKey(key);
+
+        logger.LogDebug("Getting configuration value for key '{Key}' from {StoreName}", key, storeName);
+
+        if (!configValues.TryGetValue(key, out var value))
+        {
+            logger.LogWarning("Configuration key '{Key}' not found in {StoreName}", key, storeName);
+            throw new ConfigurationNotFoundException(key);
+        }
+
+        logger.LogDebug("Successfully retrieved configuration value for key '{Key}'", key);
+
+        return Task.FromResult(value);
+    }
+
+    /// <summary>
+    /// Attempts to get a configuration value from the provided dictionary, returning
+    /// <c>null</c> when the key is absent.
+    /// </summary>
+    /// <param name="configValues">The dictionary backing the source.</param>
+    /// <param name="key">The configuration key.</param>
+    /// <returns>The configuration value, or <c>null</c> when missing.</returns>
+    public static Task<string?> TryGetConfigValueAsync(
+        IDictionary<string, string> configValues,
+        string key)
+    {
+        ArgumentNullException.ThrowIfNull(configValues);
+
+        ConfigSourceFacade.ValidateKey(key);
+
+        configValues.TryGetValue(key, out var value);
+        return Task.FromResult(value);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/DictionaryConfigLookup.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/DictionaryConfigLookup.cs
@@ -5,13 +5,16 @@ namespace HoneyDrunk.Vault.Services;
 
 /// <summary>
 /// Shared helpers for dictionary-backed configuration source implementations
-/// (in-memory, file-backed). Centralises the "validate + lookup + log" shape.
+/// (in-memory, file-backed). Each helper validates the key, performs the lookup,
+/// emits the standard log shape (when a logger is supplied), and either returns
+/// the value or throws <see cref="ConfigurationNotFoundException"/>.
 /// </summary>
 public static class DictionaryConfigLookup
 {
     /// <summary>
     /// Gets a configuration value from the provided dictionary, throwing
     /// <see cref="ConfigurationNotFoundException"/> when the key is absent.
+    /// Logs the attempt, the miss (as a warning), and the success.
     /// </summary>
     /// <param name="configValues">The dictionary backing the source.</param>
     /// <param name="key">The configuration key.</param>
@@ -37,27 +40,45 @@ public static class DictionaryConfigLookup
             throw new ConfigurationNotFoundException(key);
         }
 
-        logger.LogDebug("Successfully retrieved configuration value for key '{Key}'", key);
+        logger.LogDebug("Successfully retrieved configuration value for key '{Key}' from {StoreName}", key, storeName);
 
         return Task.FromResult(value);
     }
 
     /// <summary>
     /// Attempts to get a configuration value from the provided dictionary, returning
-    /// <c>null</c> when the key is absent.
+    /// <c>null</c> when the key is absent. When a logger is supplied, emits debug
+    /// traces for the attempt and the success/miss decision (matching the legacy
+    /// per-provider shape).
     /// </summary>
     /// <param name="configValues">The dictionary backing the source.</param>
     /// <param name="key">The configuration key.</param>
+    /// <param name="logger">The optional logger. When <c>null</c>, no log lines are emitted.</param>
+    /// <param name="storeName">A short human label used in log messages.</param>
     /// <returns>The configuration value, or <c>null</c> when missing.</returns>
     public static Task<string?> TryGetConfigValueAsync(
         IDictionary<string, string> configValues,
-        string key)
+        string key,
+        ILogger? logger = null,
+        string? storeName = null)
     {
         ArgumentNullException.ThrowIfNull(configValues);
 
         ConfigSourceFacade.ValidateKey(key);
 
+        logger?.LogDebug("Attempting to get configuration value for key '{Key}' from {StoreName}", key, storeName);
+
         configValues.TryGetValue(key, out var value);
+
+        if (value != null)
+        {
+            logger?.LogDebug("Successfully retrieved configuration value for key '{Key}' from {StoreName}", key, storeName);
+        }
+        else
+        {
+            logger?.LogDebug("Configuration value for key '{Key}' not found in {StoreName}", key, storeName);
+        }
+
         return Task.FromResult(value);
     }
 }

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/DictionarySecretLookup.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/DictionarySecretLookup.cs
@@ -1,0 +1,87 @@
+using HoneyDrunk.Vault.Exceptions;
+using HoneyDrunk.Vault.Models;
+using Microsoft.Extensions.Logging;
+
+namespace HoneyDrunk.Vault.Services;
+
+/// <summary>
+/// Shared helpers for dictionary-backed secret store implementations
+/// (in-memory, file-backed). Centralises the "log + lookup + throw" shape.
+/// </summary>
+public static class DictionarySecretLookup
+{
+    /// <summary>
+    /// Gets a secret value from the provided dictionary, logging at each step
+    /// and throwing <see cref="SecretNotFoundException"/> when the key is absent.
+    /// </summary>
+    /// <param name="secrets">The dictionary backing the store.</param>
+    /// <param name="identifier">The secret identifier.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="storeName">A short human label used in log messages (e.g., "in-memory store").</param>
+    /// <returns>The secret value reporting <c>"latest"</c> as the version.</returns>
+    public static Task<SecretValue> GetSecretAsync(
+        IDictionary<string, string> secrets,
+        SecretIdentifier identifier,
+        ILogger logger,
+        string storeName)
+    {
+        ArgumentNullException.ThrowIfNull(secrets);
+        ArgumentNullException.ThrowIfNull(identifier);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        logger.LogDebug("Getting secret '{SecretName}' from {StoreName}", identifier.Name, storeName);
+
+        if (!secrets.TryGetValue(identifier.Name, out var value))
+        {
+            logger.LogWarning("Secret '{SecretName}' not found in {StoreName}", identifier.Name, storeName);
+            throw new SecretNotFoundException(identifier.Name);
+        }
+
+        var secretValue = new SecretValue(identifier, value, "latest");
+        logger.LogDebug("Successfully retrieved secret '{SecretName}' from {StoreName}", identifier.Name, storeName);
+
+        return Task.FromResult(secretValue);
+    }
+
+    /// <summary>
+    /// Lists versions for a secret backed by a dictionary. Dictionary stores expose a
+    /// single <c>"latest"</c> version and throw <see cref="SecretNotFoundException"/>
+    /// when the key is absent.
+    /// </summary>
+    /// <param name="secrets">The dictionary backing the store.</param>
+    /// <param name="secretName">The secret name.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="storeName">A short human label used in log messages.</param>
+    /// <returns>A single-element list with <c>"latest"</c>.</returns>
+    public static Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(
+        IDictionary<string, string> secrets,
+        string secretName,
+        ILogger logger,
+        string storeName)
+    {
+        ArgumentNullException.ThrowIfNull(secrets);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        if (string.IsNullOrWhiteSpace(secretName))
+        {
+            throw new ArgumentException("Secret name cannot be null or whitespace.", nameof(secretName));
+        }
+
+        logger.LogDebug("Listing versions for secret '{SecretName}' from {StoreName}", secretName, storeName);
+
+        if (!secrets.ContainsKey(secretName))
+        {
+            logger.LogWarning("Secret '{SecretName}' not found in {StoreName}", secretName, storeName);
+            throw new SecretNotFoundException(secretName);
+        }
+
+        var versions = new List<SecretVersion>
+        {
+            new("latest", DateTimeOffset.UtcNow),
+        };
+
+        logger.LogDebug("Listed {Count} version for secret '{SecretName}'", versions.Count, secretName);
+
+        return Task.FromResult<IReadOnlyList<SecretVersion>>(versions);
+    }
+}

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/DictionarySecretLookup.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/Services/DictionarySecretLookup.cs
@@ -80,7 +80,7 @@ public static class DictionarySecretLookup
             new("latest", DateTimeOffset.UtcNow),
         };
 
-        logger.LogDebug("Listed {Count} version for secret '{SecretName}'", versions.Count, secretName);
+        logger.LogDebug("Listed {Count} version(s) for secret '{SecretName}' from {StoreName}", versions.Count, secretName, storeName);
 
         return Task.FromResult<IReadOnlyList<SecretVersion>>(versions);
     }


### PR DESCRIPTION
## Summary

- **Sonar duplication reduction (ADR-0011 D11).** The nine secret-store / config-source files that flagged with high "Duplicated Lines on New Code" percentages (`InMemorySecretStore` 35.5%, `ConfigurationSecretStore` 25.8%, `FileSecretStore` 21.6%, `InMemoryConfigSource` 18.8%, `AzureKeyVaultSecretStore` 16.0%, `FileConfigSource` 13.7%, `AwsSecretsManagerSecretStore` 10.6%, `CompositeConfigSource` 7.5%, `CompositeSecretStore` 6.5%) are addressed by two structural changes:
  - **DIM promotion.** `ISecretProvider` now extends `ISecretStore`; the `FetchSecretAsync` / `TryFetchSecretAsync` / `ListVersionsAsync` trio plus `ISecretStore.TryGetSecretAsync` are default interface methods delegating to `SecretStoreFacade`. All five concrete provider stores drop the redundant overrides.
  - **Helper extraction.** New `DictionarySecretLookup` and `DictionaryConfigLookup` static helpers in `HoneyDrunk.Vault.Services` consolidate the validate-lookup-log-throw shape used by every dictionary-backed provider. `InMemorySecretStore.GetSecretAsync` / `ListSecretVersionsAsync`, `FileSecretStore.GetSecretAsync` / `ListSecretVersionsAsync`, `InMemoryConfigSource.GetConfigValueAsync` / `TryGetConfigValueAsync`, and `FileConfigSource.GetConfigValueAsync` / `TryGetConfigValueAsync` collapse to one-line delegations.
- **Breaking changes (pre-1.0 → bumped to `0.7.0` per `0.x.0 → 0.(x+1).0`):**
  - `ISecretProvider` extends `ISecretStore`. Implementations must satisfy the `GetSecretAsync` / `ListSecretVersionsAsync` shape (Configuration intentionally stays `ISecretStore`-only and remains outside the composite chain).
  - The `Fetch*` / `TryFetch*` / `ListVersionsAsync` / `TryGetSecretAsync` DIMs are no longer overridden on the concrete providers — callers that previously hit them on the concrete class must reach them through the interface (cast or DI). Same behavioral nit acknowledged for `IConfigSource.GetConfigValueAsync<T>` in 0.6.0 (DIMs use `logger: null`, dropping per-provider debug log lines that the previous overrides emitted).
- **Coverage backfill — 53 new tests, 248 → 301 total.** Net-new files:
  - `Models/VaultScopeTests` (record equality + validation).
  - `Configuration/InMemoryVaultOptionsTests`, `Configuration/AzureKeyVaultOptionsTests`.
  - `Extensions/InMemoryServiceCollectionExtensionsTests`, `Extensions/ConfigurationServiceCollectionExtensionsTests`, `Extensions/FileVaultServiceCollectionExtensionsTests`, `Extensions/AzureKeyVaultServiceCollectionExtensionsTests`, `Extensions/AwsSecretsManagerServiceCollectionExtensionsTests`, `Extensions/VaultEventGridServiceCollectionExtensionsTests`.
  - `Services/AzureKeyVaultConfigSourceTests` (NSubstitute against `ISecretStore`).
  - `Services/AwsSecretsManagerSecretStoreTests` (NSubstitute against `IAmazonSecretsManager` — happy path, `UseVersionId`, `ResourceNotFoundException` / `AmazonSecretsManagerException` wrapping, secret-prefix, pagination, health, dispose).
  - `EventGrid/VaultInvalidationFunctionHandlerTests` (null guards + forwarding smoke test).
  - Test project now `ProjectReferences HoneyDrunk.Vault.Providers.Aws` so the AWS NSubstitute coverage can resolve `IAmazonSecretsManager`.
- **Latent DI bug fixed in `AddVaultCore`.** Previously the standalone provider extensions (`AddVaultInMemory()`, `AddVaultWithFile()`, etc.) couldn't resolve `ISecretStore` because `CompositeSecretStore`'s constructor takes `VaultTelemetry?` — but MS DI does not honor `?` annotations and was throwing `Unable to resolve service for type 'VaultTelemetry'`. `AddVaultCore` now registers `CompositeSecretStore` via a factory that calls `sp.GetService<VaultTelemetry>()` so the optional parameter binds to `null` when telemetry isn't registered. Also pre-registers a default `IOptions<VaultOptions>` so the caching factory does not blow up in that flow. Surfaces in the new extension tests.
- **No NuGet bumps.** `dotnet list package --outdated --source nuget.org` returned clean for all 9 projects after the 0.6.0 bump landed last week.
- **No new Sonar issues introduced** (no suppressions; pre-1.0 — fix at the source per `feedback/fix-dont-suppress-prerelease`).

## Validation

- `dotnet build HoneyDrunk.Vault.slnx` → 0 errors. (Only NU1900 warnings from the Azure DevOps feed 401 — pre-existing, infra issue, irrelevant to this PR.)
- `dotnet test HoneyDrunk.Vault.slnx --no-build` → **301 / 301 passing** (up from 248).
- `dotnet format HoneyDrunk.Vault.slnx --verify-no-changes` → clean.

## Test plan

- [x] `dotnet build HoneyDrunk.Vault.slnx`
- [x] `dotnet test HoneyDrunk.Vault.slnx`
- [x] `dotnet format HoneyDrunk.Vault.slnx --verify-no-changes`
- [ ] PR Core green
- [ ] SonarCloud — confirm duplication% on the changed files drops below the gate
- [ ] SonarCloud — coverage% on changed files clears the gate
- [ ] After merge: NuGet publishes 8 packages at 0.7.0

Size justification: Dedup (DIM promotion + helper extraction) and the coverage backfill both belong together � splitting would land the dedup as a 0.7.0 breaking shape, then immediately bump again as 0.7.1 for tests against the same APIs; the leak-period Sonar read is also cleaner as one PR (the duplicated-lines-on-new-code finding is what motivated the refactor in the first place). 614 non-test lines is above the ADR-0044 phase-2 advisory threshold but well within review-able scope: ~290 of those lines are removals from the five provider stores, and the rest is the two new helpers (~150 lines) + the AddVaultCore factory rewrite (~10 lines). [[feedback_pr-cadence-prefer-followups]] would normally split, but that rule applies when work is *independent*; here the tests exercise the post-refactor APIs and the helper logging shape, so they need to land together.

Out-of-band reason: ADR-0011 D11 SonarCloud-driven cleanup (dedup + coverage), no governing packet (mirrors PR #44 / #40 posture on this repo and the Kernel/AI sweep PRs).

Authorship: agent-claude-code
