### PR TITLE
[codex] Close out ADR-0086 local-worker review rollout

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+-
+
+## Validation
+
+-
+
+## Authorship
+
+Authorship: <!-- human | agent-claude-code | agent-copilot | agent-codex | mixed -->
+
+## Notes
+
+-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- Backfilled the Grid pull request template and ADR-0086 local-worker review rollout notes.


### PR DESCRIPTION
## Summary
- Close out ADR-0086 Phase B metadata for the local-worker Grid review rollout.
- Backfill the Grid PR template / changelog where missing, or align the Actions caller permission with the reusable workflow contract.

## Validation
- Confirmed .honeydrunk-review.yaml uses unner: local-worker.
- Confirmed .github/workflows/pr-review.yml grants contents: read, pull-requests: write, and issues: write.
- Confirmed the PR template carries the Authorship: line.
- Ran git diff --check.

## Smoke Test
- This PR should be reviewed by the ADR-0086 local-worker queue and should show queue, claim, and terminal review labels/comments before merge.

Authorship: agent-codex
Packet: ADR-0086 packet 09