### PR TITLE
feat(appconfig): IConfigurationManager overload so Functions/generic hosts can bootstrap App Configuration

### DIFF
--- a/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-04
+
+### Added
+- `HoneyDrunk.Vault.Providers.AppConfiguration`: `AddAppConfiguration(IConfigurationManager)` overload so Azure Functions and generic-host consumers can bootstrap App Configuration without a workaround `IConfiguration` registration. See the package CHANGELOG.
+
+### Changed
+- All Vault packages aligned to 0.8.0 (invariant 27 lockstep). Only `HoneyDrunk.Vault.Providers.AppConfiguration` changes behavior; the rest are alignment bumps.
+
 ## [0.7.0] - 2026-05-27
 
 ### Changed (breaking)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-04
+
+### Changed
+- Version alignment with the HoneyDrunk.Vault 0.8.0 release. No Event Grid-specific behavior change.
+
 ## [0.7.0] - 2026-05-27
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
@@ -8,7 +8,7 @@
     <NoWarn>$(NoWarn);CA1873</NoWarn>
 
     <PackageId>HoneyDrunk.Vault.EventGrid</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Event Grid webhook helpers for HoneyDrunk.Vault cache invalidation.</Description>
     <PackageReleaseNotes>v0.7.0: Version alignment with the HoneyDrunk.Vault 0.7.0 dedupe/coverage release (ADR-0011 D11). First test coverage added for VaultInvalidationFunctionHandler and the AddVaultEventGridInvalidation service-collection extension. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.EventGrid/HoneyDrunk.Vault.EventGrid.csproj
@@ -11,7 +11,7 @@
     <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Event Grid webhook helpers for HoneyDrunk.Vault cache invalidation.</Description>
-    <PackageReleaseNotes>v0.7.0: Version alignment with the HoneyDrunk.Vault 0.7.0 dedupe/coverage release (ADR-0011 D11). First test coverage added for VaultInvalidationFunctionHandler and the AddVaultEventGridInvalidation service-collection extension. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.8.0: Version alignment with the HoneyDrunk.Vault 0.8.0 release. No behavior change. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;eventgrid;azure;webhook;secrets;cache;rotation</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-04
+
+### Added
+- `AddAppConfiguration(IHoneyDrunkBuilder, IConfigurationManager, Action<AppConfigurationOptions>?)` overload that takes the host builder's `IConfigurationManager` directly. Hosts that do not register their `ConfigurationManager` as an `IConfiguration` instance on the service collection — Azure Functions (`FunctionsApplication.CreateBuilder`) and the generic `Host.CreateApplicationBuilder` — must use this overload (pass `builder.Configuration`); the parameterless overload's service-collection lookup falls back to an immutable env-vars-only configuration on those hosts and cannot append the App Configuration source, aborting the worker at startup.
+
+### Changed
+- The parameterless `AddAppConfiguration` overload now throws an actionable error naming the new overload when no mutable `IConfigurationManager` is registered. `WebApplication.CreateBuilder` consumers are unaffected.
+
 ## [0.7.0] - 2026-05-27
 
 ### Changed

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/Extensions/AppConfigurationBootstrapExtensions.cs
@@ -19,11 +19,20 @@ public static class AppConfigurationBootstrapExtensions
     private const string DotNetEnvironmentSetting = "DOTNET_ENVIRONMENT";
 
     /// <summary>
-    /// Adds Azure App Configuration using env-var-driven bootstrap discovery.
+    /// Adds Azure App Configuration using env-var-driven bootstrap discovery, resolving the mutable
+    /// <see cref="IConfigurationManager"/> from the service collection.
     /// Reads <c>AZURE_APPCONFIG_ENDPOINT</c> and <c>HONEYDRUNK_NODE_ID</c> via <see cref="IConfiguration"/>,
     /// applies per-Node label partitioning, enables unlabeled shared fallback keys, resolves Key Vault references,
     /// and registers feature management services.
     /// </summary>
+    /// <remarks>
+    /// This overload requires the host builder to have registered its <see cref="IConfigurationManager"/> as an
+    /// <see cref="IConfiguration"/> instance on the service collection — which <c>WebApplication.CreateBuilder</c>
+    /// does, but Azure Functions' <c>FunctionsApplication.CreateBuilder</c> and the generic
+    /// <c>Host.CreateApplicationBuilder</c> do <b>not</b>. For those hosts call the
+    /// <see cref="AddAppConfiguration(IHoneyDrunkBuilder, IConfigurationManager, Action{AppConfigurationOptions})"/>
+    /// overload and pass <c>builder.Configuration</c> directly.
+    /// </remarks>
     /// <param name="builder">The HoneyDrunk builder.</param>
     /// <param name="configure">Optional bootstrap configuration.</param>
     /// <returns>The builder for chaining.</returns>
@@ -33,13 +42,53 @@ public static class AppConfigurationBootstrapExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        var configuration = BootstrapConfigurationResolver.Resolve(builder.Services);
+        if (configuration is not IConfigurationManager manager)
+        {
+            throw new InvalidOperationException(
+                "App Configuration bootstrap requires a mutable IConfigurationManager, but the host builder did " +
+                "not register one as an IConfiguration instance on the service collection. Azure Functions' " +
+                "FunctionsApplication.CreateBuilder and the generic Host.CreateApplicationBuilder do not register " +
+                "it; call the AddAppConfiguration(IConfigurationManager) overload and pass builder.Configuration.");
+        }
+
+        return builder.AddAppConfiguration(manager, configure);
+    }
+
+    /// <summary>
+    /// Adds Azure App Configuration using env-var-driven bootstrap discovery against an explicitly supplied
+    /// <see cref="IConfigurationManager"/> (typically the host builder's <c>Configuration</c>).
+    /// Reads <c>AZURE_APPCONFIG_ENDPOINT</c> and <c>HONEYDRUNK_NODE_ID</c>, applies per-Node label partitioning,
+    /// enables unlabeled shared fallback keys, resolves Key Vault references, and registers feature management.
+    /// </summary>
+    /// <remarks>
+    /// Use this overload for hosts that do not register the manager on the service collection — Azure Functions
+    /// (<c>FunctionsApplication.CreateBuilder</c>) and the generic <c>Host.CreateApplicationBuilder</c>. Passing
+    /// the manager directly avoids the service-collection lookup the parameterless overload depends on, which on
+    /// those hosts falls back to an immutable env-vars-only configuration and cannot append the App Configuration
+    /// source (the worker then aborts at startup).
+    /// </remarks>
+    /// <param name="builder">The HoneyDrunk builder.</param>
+    /// <param name="configurationManager">
+    /// The mutable configuration manager to read bootstrap settings from and append the App Configuration source
+    /// to — typically the host builder's <c>Configuration</c>.
+    /// </param>
+    /// <param name="configure">Optional bootstrap configuration.</param>
+    /// <returns>The builder for chaining.</returns>
+    public static IHoneyDrunkBuilder AddAppConfiguration(
+        this IHoneyDrunkBuilder builder,
+        IConfigurationManager configurationManager,
+        Action<AppConfigurationOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurationManager);
+
         var options = new AppConfigurationOptions();
         configure?.Invoke(options);
 
-        var configuration = BootstrapConfigurationResolver.Resolve(builder.Services);
-        if (BootstrapConfigurationResolver.TryGetEndpoint(configuration, AppConfigurationEndpointSetting, out var endpointUri))
+        if (BootstrapConfigurationResolver.TryGetEndpoint(configurationManager, AppConfigurationEndpointSetting, out var endpointUri))
         {
-            var nodeId = configuration[NodeIdSetting]
+            var nodeId = configurationManager[NodeIdSetting]
                 ?? Environment.GetEnvironmentVariable(NodeIdSetting);
             if (string.IsNullOrWhiteSpace(nodeId))
             {
@@ -48,14 +97,8 @@ public static class AppConfigurationBootstrapExtensions
                     "HONEYDRUNK_NODE_ID is required for App Configuration label partitioning.");
             }
 
-            if (configuration is not IConfigurationManager manager)
-            {
-                throw new InvalidOperationException(
-                    "App Configuration bootstrap requires a mutable IConfigurationManager instance on the service collection.");
-            }
-
             var credential = options.Credential ?? new DefaultAzureCredential();
-            manager.AddAzureAppConfiguration(
+            configurationManager.AddAzureAppConfiguration(
                 appConfigOptions =>
                 {
                     appConfigOptions.Connect(endpointUri, credential);
@@ -80,15 +123,9 @@ public static class AppConfigurationBootstrapExtensions
             return builder;
         }
 
-        if (BootstrapConfigurationResolver.IsDevelopment(configuration, AspNetCoreEnvironmentSetting, DotNetEnvironmentSetting))
+        if (BootstrapConfigurationResolver.IsDevelopment(configurationManager, AspNetCoreEnvironmentSetting, DotNetEnvironmentSetting))
         {
-            if (configuration is not IConfigurationManager manager)
-            {
-                throw new InvalidOperationException(
-                    "Development bootstrap requires a mutable IConfigurationManager to apply appsettings.Development.json fallback.");
-            }
-
-            manager.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true);
+            configurationManager.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true);
 
             builder.Services.AddFeatureManagement();
             return builder;

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -11,7 +11,7 @@
     <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure App Configuration bootstrap extensions for HoneyDrunk.Vault using environment variable discovery.</Description>
-    <PackageReleaseNotes>v0.7.0: Version alignment with the HoneyDrunk.Vault 0.7.0 dedupe/coverage release (ADR-0011 D11). See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.8.0: Adds an AddAppConfiguration(IConfigurationManager) overload so Azure Functions and generic-host consumers can bootstrap App Configuration without a workaround registration. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;app-configuration;azure;feature-flags;configuration;bootstrap</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AppConfiguration/HoneyDrunk.Vault.Providers.AppConfiguration.csproj
@@ -8,7 +8,7 @@
     <NoWarn>$(NoWarn);CA1873</NoWarn>
 
     <PackageId>HoneyDrunk.Vault.Providers.AppConfiguration</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure App Configuration bootstrap extensions for HoneyDrunk.Vault using environment variable discovery.</Description>
     <PackageReleaseNotes>v0.7.0: Version alignment with the HoneyDrunk.Vault 0.7.0 dedupe/coverage release (ADR-0011 D11). See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-04
+
+### Changed
+- Version alignment with the HoneyDrunk.Vault 0.8.0 release. No AWS provider-specific behavior change.
+
 ## [0.7.0] - 2026-05-27
 
 ### Changed (breaking)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
@@ -12,7 +12,7 @@
     <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>AWS Secrets Manager provider for HoneyDrunk.Vault. Provides secure secret management using AWS Secrets Manager with support for IAM roles, access keys, and EC2 instance profiles.</Description>
-    <PackageReleaseNotes>v0.7.0: AwsSecretsManagerSecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). First test coverage added (NSubstitute against IAmazonSecretsManager). See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.8.0: Version alignment with the HoneyDrunk.Vault 0.8.0 release. No behavior change. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;aws;secrets-manager;iam;access-keys;instance-profile;ec2;authentication</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Aws/HoneyDrunk.Vault.Providers.Aws.csproj
@@ -9,7 +9,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Aws</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>AWS Secrets Manager provider for HoneyDrunk.Vault. Provides secure secret management using AWS Secrets Manager with support for IAM roles, access keys, and EC2 instance profiles.</Description>
     <PackageReleaseNotes>v0.7.0: AwsSecretsManagerSecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). First test coverage added (NSubstitute against IAmazonSecretsManager). See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-04
+
+### Changed
+- Version alignment with the HoneyDrunk.Vault 0.8.0 release. No Azure Key Vault provider-specific behavior change.
+
 ## [0.7.0] - 2026-05-27
 
 ### Changed (breaking)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -9,7 +9,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.AzureKeyVault</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Key Vault provider for HoneyDrunk.Vault. Provides enterprise-grade secret management using Azure Key Vault with support for Managed Identity and Service Principal authentication.</Description>
     <PackageReleaseNotes>v0.7.0: AzureKeyVaultSecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). First test coverage added for AzureKeyVaultConfigSource. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.AzureKeyVault/HoneyDrunk.Vault.Providers.AzureKeyVault.csproj
@@ -12,7 +12,7 @@
     <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Key Vault provider for HoneyDrunk.Vault. Provides enterprise-grade secret management using Azure Key Vault with support for Managed Identity and Service Principal authentication.</Description>
-    <PackageReleaseNotes>v0.7.0: AzureKeyVaultSecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). First test coverage added for AzureKeyVaultConfigSource. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.8.0: Version alignment with the HoneyDrunk.Vault 0.8.0 release. No behavior change. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;azure;key-vault;managed-identity;service-principal;authentication;enterprise</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-04
+
+### Changed
+- Version alignment with the HoneyDrunk.Vault 0.8.0 release. No Configuration provider-specific behavior change.
+
 ## [0.7.0] - 2026-05-27
 
 ### Changed (breaking)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
@@ -12,7 +12,7 @@
     <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>.NET Configuration provider for HoneyDrunk.Vault. Enables reading secrets and configuration from standard .NET configuration sources (appsettings.json, environment variables, user secrets).</Description>
-    <PackageReleaseNotes>v0.7.0: ConfigurationSecretStore drops the redundant TryGetSecretAsync override now that ISecretStore supplies it as a default interface method (breaking — see HoneyDrunk.Vault 0.7.0 notes). See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.8.0: Version alignment with the HoneyDrunk.Vault 0.8.0 release. No behavior change. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;configuration;secrets;appsettings;environment-variables;user-secrets;dotnet-config</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.Configuration/HoneyDrunk.Vault.Providers.Configuration.csproj
@@ -9,7 +9,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.Configuration</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>.NET Configuration provider for HoneyDrunk.Vault. Enables reading secrets and configuration from standard .NET configuration sources (appsettings.json, environment variables, user secrets).</Description>
     <PackageReleaseNotes>v0.7.0: ConfigurationSecretStore drops the redundant TryGetSecretAsync override now that ISecretStore supplies it as a default interface method (breaking — see HoneyDrunk.Vault 0.7.0 notes). See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-04
+
+### Changed
+- Version alignment with the HoneyDrunk.Vault 0.8.0 release. No File provider-specific behavior change.
+
 ## [0.7.0] - 2026-05-27
 
 ### Changed (breaking)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
@@ -12,7 +12,7 @@
     <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>File-based secrets and configuration provider for HoneyDrunk.Vault. Ideal for local development and testing with support for file watching and optional encryption.</Description>
-    <PackageReleaseNotes>v0.7.0: FileSecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). FileSecretStore and FileConfigSource now share new DictionarySecretLookup / DictionaryConfigLookup helpers in HoneyDrunk.Vault. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.8.0: Version alignment with the HoneyDrunk.Vault 0.8.0 release. No behavior change. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;configuration;file;development;testing;file-watcher</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.File/HoneyDrunk.Vault.Providers.File.csproj
@@ -9,7 +9,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.File</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>File-based secrets and configuration provider for HoneyDrunk.Vault. Ideal for local development and testing with support for file watching and optional encryption.</Description>
     <PackageReleaseNotes>v0.7.0: FileSecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). FileSecretStore and FileConfigSource now share new DictionarySecretLookup / DictionaryConfigLookup helpers in HoneyDrunk.Vault. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-04
+
+### Changed
+- Version alignment with the HoneyDrunk.Vault 0.8.0 release. No InMemory provider-specific behavior change.
+
 ## [0.7.0] - 2026-05-27
 
 ### Changed (breaking)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
@@ -9,7 +9,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault.Providers.InMemory</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory provider for HoneyDrunk.Vault. Ideal for unit testing and integration testing with fast, thread-safe secret and configuration storage.</Description>
     <PackageReleaseNotes>v0.7.0: InMemorySecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). InMemorySecretStore and InMemoryConfigSource now share new DictionarySecretLookup / DictionaryConfigLookup helpers in HoneyDrunk.Vault. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Providers.InMemory/HoneyDrunk.Vault.Providers.InMemory.csproj
@@ -12,7 +12,7 @@
     <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>In-memory provider for HoneyDrunk.Vault. Ideal for unit testing and integration testing with fast, thread-safe secret and configuration storage.</Description>
-    <PackageReleaseNotes>v0.7.0: InMemorySecretStore drops the redundant TryGetSecretAsync / FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync overrides now that ISecretStore / ISecretProvider supply them as default interface methods (breaking — see HoneyDrunk.Vault 0.7.0 notes). InMemorySecretStore and InMemoryConfigSource now share new DictionarySecretLookup / DictionaryConfigLookup helpers in HoneyDrunk.Vault. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.8.0: Version alignment with the HoneyDrunk.Vault 0.8.0 release. No behavior change. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;provider;secrets;testing;unit-testing;in-memory;mock;development</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
@@ -26,6 +26,7 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         services.AddSingleton<IConfiguration>(configuration);
 
         var builder = CreateBuilder(services);
+        var sourceCountBefore = configuration.Sources.Count;
 
         var result = builder.AddAppConfiguration(o =>
         {
@@ -35,7 +36,7 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         });
 
         Assert.Same(builder, result);
-        Assert.Contains(configuration.Sources, s => s.GetType().Name.Contains("AzureAppConfiguration", StringComparison.Ordinal));
+        Assert.True(configuration.Sources.Count > sourceCountBefore, "An Azure App Configuration source should be appended to the manager.");
         Assert.Contains(services, d => d.ServiceType.FullName == "Microsoft.FeatureManagement.IFeatureManager");
     }
 
@@ -89,6 +90,7 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         // configuration is deliberately NOT registered on `services` — this mimics
         // FunctionsApplication.CreateBuilder, which does not register its ConfigurationManager instance.
         var builder = CreateBuilder(services);
+        var sourceCountBefore = configuration.Sources.Count;
 
         var result = builder.AddAppConfiguration(configuration, o =>
         {
@@ -98,7 +100,7 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         });
 
         Assert.Same(builder, result);
-        Assert.Contains(configuration.Sources, s => s.GetType().Name.Contains("AzureAppConfiguration", StringComparison.Ordinal));
+        Assert.True(configuration.Sources.Count > sourceCountBefore, "An Azure App Configuration source should be appended to the explicitly supplied manager.");
         Assert.Contains(services, d => d.ServiceType.FullName == "Microsoft.FeatureManagement.IFeatureManager");
     }
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
@@ -37,7 +37,7 @@ public sealed class AppConfigurationBootstrapExtensionsTests
 
         Assert.Same(builder, result);
         Assert.True(configuration.Sources.Count > sourceCountBefore, "An Azure App Configuration source should be appended to the manager.");
-        Assert.Contains(services, d => d.ServiceType.FullName == "Microsoft.FeatureManagement.IFeatureManager");
+        Assert.Contains(services, d => d.ServiceType == typeof(Microsoft.FeatureManagement.IFeatureManager));
     }
 
     /// <summary>
@@ -101,7 +101,7 @@ public sealed class AppConfigurationBootstrapExtensionsTests
 
         Assert.Same(builder, result);
         Assert.True(configuration.Sources.Count > sourceCountBefore, "An Azure App Configuration source should be appended to the explicitly supplied manager.");
-        Assert.Contains(services, d => d.ServiceType.FullName == "Microsoft.FeatureManagement.IFeatureManager");
+        Assert.Contains(services, d => d.ServiceType == typeof(Microsoft.FeatureManagement.IFeatureManager));
     }
 
     /// <summary>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
@@ -73,6 +73,49 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         Assert.Throws<InvalidOperationException>(() => builder.AddAppConfiguration());
     }
 
+    /// <summary>
+    /// Verifies the explicit-manager overload registers the Azure source even when the service collection has
+    /// no <see cref="IConfiguration"/> registered — the Azure Functions / generic-host case the parameterless
+    /// overload cannot serve.
+    /// </summary>
+    [Fact]
+    public void AddAppConfiguration_WithExplicitManager_RegistersAzureSource_WhenServicesHaveNoConfiguration()
+    {
+        var services = new ServiceCollection();
+        using var configuration = new ConfigurationManager();
+        configuration["AZURE_APPCONFIG_ENDPOINT"] = "https://appcs-test.azconfig.io";
+        configuration["HONEYDRUNK_NODE_ID"] = "orders";
+
+        // configuration is deliberately NOT registered on `services` — this mimics
+        // FunctionsApplication.CreateBuilder, which does not register its ConfigurationManager instance.
+        var builder = CreateBuilder(services);
+
+        var result = builder.AddAppConfiguration(configuration, o =>
+        {
+            o.Optional = true;
+            o.Credential = new StaticTokenCredential();
+            o.StartupTimeout = TimeSpan.FromMilliseconds(1);
+        });
+
+        Assert.Same(builder, result);
+        Assert.Contains(configuration.Sources, s => s.GetType().Name.Contains("AzureAppConfiguration", StringComparison.Ordinal));
+        Assert.Contains(services, d => d.ServiceType.FullName == "Microsoft.FeatureManagement.IFeatureManager");
+    }
+
+    /// <summary>
+    /// Verifies the parameterless overload throws actionable guidance (pointing to the manager overload) when
+    /// the host builder did not register a mutable <see cref="IConfigurationManager"/> on the service collection.
+    /// </summary>
+    [Fact]
+    public void AddAppConfiguration_Throws_WithOverloadGuidance_WhenServicesHaveNoConfigurationManager()
+    {
+        var services = new ServiceCollection();
+        var builder = CreateBuilder(services);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.AddAppConfiguration());
+        Assert.Contains("AddAppConfiguration(IConfigurationManager)", ex.Message, StringComparison.Ordinal);
+    }
+
     private static IHoneyDrunkBuilder CreateBuilder(IServiceCollection services)
     {
         var builder = Substitute.For<IHoneyDrunkBuilder>();

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault.Tests/Extensions/AppConfigurationBootstrapExtensionsTests.cs
@@ -26,7 +26,6 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         services.AddSingleton<IConfiguration>(configuration);
 
         var builder = CreateBuilder(services);
-        var sourceCountBefore = configuration.Sources.Count;
 
         var result = builder.AddAppConfiguration(o =>
         {
@@ -36,7 +35,8 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         });
 
         Assert.Same(builder, result);
-        Assert.True(configuration.Sources.Count > sourceCountBefore, "An Azure App Configuration source should be appended to the manager.");
+        var azureAppConfigAssembly = typeof(Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureAppConfigurationOptions).Assembly;
+        Assert.Contains(configuration.Sources, s => s.GetType().Assembly == azureAppConfigAssembly);
         Assert.Contains(services, d => d.ServiceType == typeof(Microsoft.FeatureManagement.IFeatureManager));
     }
 
@@ -90,7 +90,6 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         // configuration is deliberately NOT registered on `services` — this mimics
         // FunctionsApplication.CreateBuilder, which does not register its ConfigurationManager instance.
         var builder = CreateBuilder(services);
-        var sourceCountBefore = configuration.Sources.Count;
 
         var result = builder.AddAppConfiguration(configuration, o =>
         {
@@ -100,7 +99,8 @@ public sealed class AppConfigurationBootstrapExtensionsTests
         });
 
         Assert.Same(builder, result);
-        Assert.True(configuration.Sources.Count > sourceCountBefore, "An Azure App Configuration source should be appended to the explicitly supplied manager.");
+        var azureAppConfigAssembly = typeof(Microsoft.Extensions.Configuration.AzureAppConfiguration.AzureAppConfigurationOptions).Assembly;
+        Assert.Contains(configuration.Sources, s => s.GetType().Assembly == azureAppConfigAssembly);
         Assert.Contains(services, d => d.ServiceType == typeof(Microsoft.FeatureManagement.IFeatureManager));
     }
 

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-04
+
+### Changed
+- Version alignment with the HoneyDrunk.Vault 0.8.0 release. No Vault core-specific behavior change.
+
 ## [0.7.0] - 2026-05-27
 
 ### Changed (breaking)

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
@@ -12,7 +12,7 @@
     <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Secrets and configuration management library for .NET. Provides a unified abstraction for accessing secrets from multiple providers (File, Azure Key Vault, AWS Secrets Manager, Configuration, In-Memory). Integrated with HoneyDrunk.Kernel v0.8.0 for lifecycle management, health reporting, and distributed telemetry.</Description>
-    <PackageReleaseNotes>v0.7.0: Sonar duplication reduction (ADR-0011 D11) + coverage backfill. ISecretProvider now extends ISecretStore and exposes the FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync trio as default interface methods delegating to SecretStoreFacade; ISecretStore.TryGetSecretAsync is similarly a DIM (breaking — existing implementers may no longer need the redundant overrides). New DictionarySecretLookup / DictionaryConfigLookup helpers consolidate the in-memory/file-store lookup pattern. AddVaultCore now resolves the composite via a factory so the optional VaultTelemetry parameter binds to null when telemetry is disabled. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.8.0: Version alignment with the HoneyDrunk.Vault 0.8.0 release. No behavior change. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>vault;secrets;configuration;provider;cache;resilience;circuit-breaker;retry;azure-keyvault;aws;kernel;grid;distributed-tracing</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
+++ b/HoneyDrunk.Vault/HoneyDrunk.Vault/HoneyDrunk.Vault.csproj
@@ -9,7 +9,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Vault</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Secrets and configuration management library for .NET. Provides a unified abstraction for accessing secrets from multiple providers (File, Azure Key Vault, AWS Secrets Manager, Configuration, In-Memory). Integrated with HoneyDrunk.Kernel v0.8.0 for lifecycle management, health reporting, and distributed telemetry.</Description>
     <PackageReleaseNotes>v0.7.0: Sonar duplication reduction (ADR-0011 D11) + coverage backfill. ISecretProvider now extends ISecretStore and exposes the FetchSecretAsync / TryFetchSecretAsync / ListVersionsAsync trio as default interface methods delegating to SecretStoreFacade; ISecretStore.TryGetSecretAsync is similarly a DIM (breaking — existing implementers may no longer need the redundant overrides). New DictionarySecretLookup / DictionaryConfigLookup helpers consolidate the in-memory/file-store lookup pattern. AddVaultCore now resolves the composite via a factory so the optional VaultTelemetry parameter binds to null when telemetry is disabled. See CHANGELOG.md for details.</PackageReleaseNotes>


### PR DESCRIPTION
## Summary
`AddAppConfiguration` resolves `IConfiguration` from the service collection and **requires the mutable `IConfigurationManager`** to append the Azure App Configuration source. `WebApplication.CreateBuilder` registers its `ConfigurationManager` as an `IConfiguration` instance so the lookup works — but **Azure Functions' `FunctionsApplication.CreateBuilder` and the generic `Host.CreateApplicationBuilder` do not**, so the lookup falls back to an immutable env-vars-only configuration and the worker aborts at startup.

This is the durable fix for the Notify.Functions SIGABRT crash (worked around consumer-side in HoneyDrunk.Notify #56 with `builder.Services.AddSingleton<IConfiguration>(builder.Configuration)`). Pulse.Collector carries a similar defensive `Replace` workaround. This PR makes the package support those hosts as first-class.

## Change
- **New overload** `AddAppConfiguration(this IHoneyDrunkBuilder, IConfigurationManager, Action<AppConfigurationOptions>?)` — takes the host builder's `Configuration` directly and uses it for both reading bootstrap settings and appending the App Config source, skipping the service-collection lookup entirely.
- The **parameterless overload** now delegates to it and, when no mutable manager is registered, throws an **actionable error naming the new overload** (previously a less specific bootstrap error). `WebApplication.CreateBuilder` consumers are unchanged.

Consumer usage (Functions / generic host):
```csharp
builder.Services
    .AddHoneyDrunkNode(...)
    .AddVaultWithAzureKeyVaultBootstrap()
    .AddAppConfiguration(builder.Configuration);   // pass the manager
```

## Validation
- `dotnet build -c Release` — 0 errors. `dotnet format --verify-no-changes` — clean.
- `dotnet test` (AppConfiguration bootstrap) — **5/5 pass**, including two new tests: the explicit-manager overload works against an empty service collection (the Functions case), and the parameterless overload throws with overload guidance when no manager is registered.

## Versioning
All Vault packages bumped **0.7.0 → 0.8.0** (invariant 27 lockstep, additive feature = minor). Only `HoneyDrunk.Vault.Providers.AppConfiguration` has a behavior change; the other seven are alignment bumps (per-package CHANGELOGs note this). Repo + per-package CHANGELOGs updated with `## [0.8.0]` headings.

## Follow-ups (separate PRs, gated on this publishing)
- **HoneyDrunk.Notify**: bump the `HoneyDrunk.Vault.Providers.AppConfiguration` reference to 0.8.0 and switch Notify.Functions to `.AddAppConfiguration(builder.Configuration)`, removing the `#56` workaround.
- **HoneyDrunk.Pulse**: drop the defensive `Replace(ServiceDescriptor.Singleton<IConfiguration>(...))` in Pulse.Collector (optionally adopt the overload).

Authorship: agent-claude-code
Out-of-band reason: Durable Vault fix surfaced by the Notify.Functions crash during ADR-0033/ADR-0015 deploy verification; not a pre-scoped packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)